### PR TITLE
Create preferences page

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.classpath
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.project
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.discord.rpc.integration.ui.preferences</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Discord Integration Preferences
+Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
+Require-Bundle: org.eclipse.ui,
+  org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.ui.preferences
+Bundle-ActivationPolicy: lazy

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/build.properties
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+
+</plugin>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            class="fr.kazejiyu.discord.rpc.integration.ui.preferences.DiscordIntegrationPreferences"
+            id="fr.kazejiyu.discord.rpc.integration.ui.preferences.root"
+            name="Discord Integration">
+      </page>
+   </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="fr.kazejiyu.discord.rpc.integration.ui.preferences.DiscordIntegrationPreferencesInitializer">
+      </initializer>
+   </extension>
 </plugin>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/Activator.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/Activator.java
@@ -1,0 +1,46 @@
+package fr.kazejiyu.discord.rpc.integration.ui.preferences;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends AbstractUIPlugin {
+
+	// The plug-in ID
+	public static final String PLUGIN_ID = "fr.kazejiyu.discord.rpc.integration.ui.preferences"; //$NON-NLS-1$
+
+	// The shared instance
+	private static Activator plugin;
+	
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+	 */
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferences.java
@@ -1,0 +1,28 @@
+package fr.kazejiyu.discord.rpc.integration.ui.preferences;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+public class DiscordIntegrationPreferences extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	public DiscordIntegrationPreferences() {
+		super(GRID);
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store"));
+		setDescription("Customize the way informations are shown in Discord");
+	}
+
+	@Override
+    public void createFieldEditors() {
+        addField(new BooleanFieldEditor("SHOW_FILE_NAME", "Show &file's name", getFieldEditorParent()));
+        addField(new BooleanFieldEditor("SHOW_PROJECT_NAME", "Show &project's name", getFieldEditorParent()));
+    }
+    
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
@@ -1,0 +1,16 @@
+package fr.kazejiyu.discord.rpc.integration.ui.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+
+public class DiscordIntegrationPreferencesInitializer extends AbstractPreferenceInitializer {
+	
+	@Override
+	public void initializeDefaultPreferences() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		
+        store.setDefault("SHOW_FILE_NAME", true);
+        store.setDefault("SHOW_PROJECT_NAME", true);
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordIntegrationPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordIntegrationPreferences.java
@@ -1,0 +1,28 @@
+package fr.kazejiyu.discord.rpc.integration.core;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+/**
+ * Provides easy access to the settings defined by the user for Discord Integration.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public enum DiscordIntegrationPreferences {
+	
+	INSTANCE;
+	
+	/** @return whether the name of the edited file should be shown in Discord */
+	public boolean showsFileName() {
+		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
+		return s.getBoolean("SHOW_FILE_NAME");
+	}
+	
+	/** @return whether the name of the current project should be shown in Discord */
+	public boolean showsProjectName() {
+		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
+		return s.getBoolean("SHOW_PROJECT_NAME");
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/AddListenerOnWindowOpened.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/AddListenerOnWindowOpened.java
@@ -62,8 +62,12 @@ public class AddListenerOnWindowOpened<T extends ISelectionListener & IPartListe
     }
     
     @Override
-    public void windowActivated(IWorkbenchWindow window) {}
+    public void windowActivated(IWorkbenchWindow window) {
+    	// irrelevant event
+    }
     
     @Override
-    public void windowDeactivated(IWorkbenchWindow window) {}
+    public void windowDeactivated(IWorkbenchWindow window) {
+    	// irrelevant event
+    }
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
@@ -15,6 +15,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.part.EditorPart;
 
+import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
 import fr.kazejiyu.discord.rpc.integration.core.DiscordRpcProxy;
 
 /**
@@ -24,9 +25,13 @@ import fr.kazejiyu.discord.rpc.integration.core.DiscordRpcProxy;
  */
 public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartListener2 {
 	
+	/** Communicates informations to Discord */
 	private final DiscordRpcProxy rpc = new DiscordRpcProxy();
 	
 	private IWorkbenchPart lastSelectedPart = null;
+
+	/** User's preferences */
+	private static final DiscordIntegrationPreferences preferences = DiscordIntegrationPreferences.INSTANCE;
 	
 	public NotifyDiscordRpcOnSelection() {
 		rpc.initialize();
@@ -45,8 +50,17 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 			IFile inEdition = ((IFileEditorInput) editor.getEditorInput()).getFile();
 			IProject project = inEdition.getProject();
 			
-			String details = "Editing " + inEdition.getName();
-			String state = (project != null) ? "Working on " + project.getName() : "";
+			String details, state;
+			
+			if (preferences.showsFileName())
+				details = "Editing " + inEdition.getName();
+			else
+				details = "Editing a mysterious file";
+			
+			if (preferences.showsProjectName())
+				state = (project != null) ? "Working on " + project.getName() : "";
+			else
+				state = "Working on a mysterious project";	
 				
 			rpc.setInformations(details, state);
 			lastSelectedPart = part;
@@ -57,8 +71,17 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 			
 			File editedFile = new File(inEdition.getPath());
 			
-			String details = editedFile.exists() ? "Editing " + editedFile.getName() : "";
-			String state = "Unknown project";
+			String details, state;
+			
+			if (preferences.showsFileName())
+				details = editedFile.exists() ? "Editing " + editedFile.getName() : "";
+			else
+				details = "Editing a mysterious file";
+			
+			if (preferences.showsProjectName())
+				state = "Unknown project";
+			else
+				state = "Working on a mysterious project";
 				
 			rpc.setInformations(details, state);
 			lastSelectedPart = part;
@@ -79,21 +102,33 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 	}
 
 	@Override
-	public void partBroughtToTop(IWorkbenchPartReference partRef) {}
+	public void partBroughtToTop(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 
 	@Override
-	public void partDeactivated(IWorkbenchPartReference partRef) {}
+	public void partDeactivated(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 
 	@Override
-	public void partOpened(IWorkbenchPartReference partRef) {}
+	public void partOpened(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 
 	@Override
-	public void partHidden(IWorkbenchPartReference partRef) {}
+	public void partHidden(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 
 	@Override
-	public void partVisible(IWorkbenchPartReference partRef) {}
+	public void partVisible(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 
 	@Override
-	public void partInputChanged(IWorkbenchPartReference partRef) {}
+	public void partInputChanged(IWorkbenchPartReference partRef) {
+		// irrelevant event
+	}
 	
 }


### PR DESCRIPTION
Add a page to Eclipse IDE's Preferences allowing the user to choose whether the following information should be shown in Discord:

- the edited file's name,
- the current project's name.