### PR TITLE
Customize EditorInput Adapter through extension points

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.classpath
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.project
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.discord.rpc.integration.adapters</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Discord Integration Default Adapters
+Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: fr.kazejiyu.discord.rpc.integration,
+ org.eclipse.ui.workbench,
+ org.eclipse.ui.ide;bundle-version="3.13.1",
+ org.eclipse.core.resources

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/build.properties
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="fr.kazejiyu.discord.rpc.integration.editor_input_default_adapters">
+      <adapter
+            class="fr.kazejiyu.discord.rpc.integration.adapters.DefaultURIEditorInputRichPresence">
+      </adapter>
+      <adapter
+            class="fr.kazejiyu.discord.rpc.integration.adapters.DefaultFileEditorInputRichPresence">
+      </adapter>
+   </extension> 
+
+</plugin>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -1,0 +1,79 @@
+package fr.kazejiyu.discord.rpc.integration.adapters;
+
+import java.util.Optional;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IFileEditorInput;
+
+import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
+import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.extensions.RichPresence;
+
+/**
+ * Default implementation of {@link EditorInputRichPresence}.<br>
+ * <br>
+ * This implementation only operates on {@link IFileEditorInput} instances and set Rich Presence as follows:
+ * 
+ * <table style="border: 1px solid black ; border-collapse: collapse">
+ * 	<tr style="border: 1px solid black">
+ * 		<th style="border: 1px solid black">Property</th>
+ * 		<th style="border: 1px solid black">If shown</th>
+ * 		<th style="border: 1px solid black">If not shown</th>
+ * 	</tr>
+ * 	<tr>
+ * 		<td style="border: 1px solid black"><b>Details</b></td>
+ * 		<td style="border: 1px solid black">Editing <i>&lt;file.name&gt;</i></td>
+ * 		<td style="border: 1px solid black">Working on a mysterious file</td>
+ * 	</tr>
+ * 	<tr>
+ * 		<td style="border: 1px solid black"><b>State</b></td>
+ * 		<td style="border: 1px solid black">Working on <i>&lt;project.name&gt;</i></td>
+ * 		<td style="border: 1px solid black">Working on a mysterious project</td>
+ * 	</tr>
+ * </table>
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class DefaultFileEditorInputRichPresence implements EditorInputRichPresence {
+	
+	@Override
+	public Class<IFileEditorInput> getExpectedEditorInputClass() {
+		return IFileEditorInput.class;
+	}
+	
+	@Override
+	public Optional<RichPresence> createRichPresence(DiscordIntegrationPreferences preferences, IEditorInput input) {
+		if (!(input instanceof IFileEditorInput))
+			throw new IllegalArgumentException("input must be an instance of " + IFileEditorInput.class);
+		
+		RichPresence presence = new RichPresence();
+		IFileEditorInput fileInput = (IFileEditorInput) input;
+		
+		presence.setDetails(detailsOf(preferences, fileInput));
+		presence.setState(stateOf(preferences, fileInput));
+		
+		return Optional.of(presence);
+	}
+
+	private String detailsOf(DiscordIntegrationPreferences preferences, IFileEditorInput input) {
+		if (! preferences.showsFileName())
+			return "Editing a mysterious file";
+		
+		IFile inEdition = input.getFile();
+		
+		return "Editing " + inEdition.getName();
+	}
+
+	private String stateOf(DiscordIntegrationPreferences preferences, IFileEditorInput input) {
+		if (! preferences.showsProjectName())
+			return "Working on a mysterious project";
+		
+		IFile inEdition = input.getFile();
+		IProject project = inEdition.getProject();
+		
+		return "Working on " + ((project != null) ? project.getName() : "an unknown project");
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
@@ -1,0 +1,83 @@
+package fr.kazejiyu.discord.rpc.integration.adapters;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Optional;
+
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IURIEditorInput;
+import org.eclipse.ui.ide.FileStoreEditorInput;
+
+import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
+import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.extensions.RichPresence;
+
+/**
+ * Default implementation of {@link EditorInputRichPresence}.<br>
+ * <br>
+ * This implementation only operates on {@link IURIEditorInput} instances and set Rich Presence as follows:
+ * 
+ * <table style="border: 1px solid black ; border-collapse: collapse">
+ * 	<tr style="border: 1px solid black">
+ * 		<th style="border: 1px solid black">Property</th>
+ * 		<th style="border: 1px solid black">If shown</th>
+ * 		<th style="border: 1px solid black">If not shown</th>
+ * 	</tr>
+ * 	<tr>
+ * 		<td style="border: 1px solid black"><b>Details</b></td>
+ * 		<td style="border: 1px solid black">Editing <i>&lt;file.name&gt;</i></td>
+ * 		<td style="border: 1px solid black">Working on a mysterious file</td>
+ * 	</tr>
+ * 	<tr>
+ * 		<td style="border: 1px solid black"><b>State</b></td>
+ * 		<td style="border: 1px solid black">Working on <i>&lt;project.name&gt;</i></td>
+ * 		<td style="border: 1px solid black">Working on a mysterious project</td>
+ * 	</tr>
+ * </table>
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class DefaultURIEditorInputRichPresence implements EditorInputRichPresence {
+	
+	@Override
+	public Class<FileStoreEditorInput> getExpectedEditorInputClass() {
+		return FileStoreEditorInput.class;
+		
+		// TODO Handle inheritance so that returning IURIEditorInput.class here does not prevent
+		// DefaultFileEditorInputRichPresence to be taken into account at runtime
+//		return IURIEditorInput.class;
+	}
+	
+	@Override
+	public Optional<RichPresence> createRichPresence(DiscordIntegrationPreferences preferences, IEditorInput input) {
+		if (!(input instanceof IURIEditorInput))
+			throw new IllegalArgumentException("input must be an instance of " + IURIEditorInput.class);
+		
+		IURIEditorInput uriInput = (IURIEditorInput) input;
+		
+		RichPresence presence = new RichPresence();
+		
+		presence.setDetails(detailsOf(preferences, uriInput));
+		presence.setState(stateOf(preferences, uriInput));
+		
+		return Optional.of(presence);
+	}
+
+	private String detailsOf(DiscordIntegrationPreferences preferences, IURIEditorInput input) {
+		if (! preferences.showsFileName())
+			return "Editing a mysterious file";
+		
+		URI inEdition = input.getURI();
+		File editedFile = new File(inEdition.getPath());
+		
+		return "Editing " + editedFile.getName();
+	}
+
+	private String stateOf(DiscordIntegrationPreferences preferences, IURIEditorInput input) {
+		if (! preferences.showsProjectName())
+			return "Working on a mysterious project";
+		
+		return "Unknown project";
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/package-info.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Default implementations for {@link fr.kazejiyu.discord.rpc.integration.extensions.RichPresence RichPresence}
+ * interface.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+package fr.kazejiyu.discord.rpc.integration.adapters;

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.13.1",
  org.eclipse.core.resources;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: fr.kazejiyu.discord.rpc.integration.extensions

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.13.1",
  org.eclipse.core.resources;bundle-version="3.12.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: fr.kazejiyu.discord.rpc.integration.extensions
+Export-Package: fr.kazejiyu.discord.rpc.integration.core,
+ fr.kazejiyu.discord.rpc.integration.extensions

--- a/bundles/fr.kazejiyu.discord.rpc.integration/build.properties
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.discord.rpc.integration/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <plugin>
+   <extension-point id="editor_input_adapter" name="EditorInput Adapter" schema="schema/editor_input_adapter.exsd"/>
    <extension
          point="org.eclipse.ui.startup">
       <startup

--- a/bundles/fr.kazejiyu.discord.rpc.integration/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/plugin.xml
@@ -2,6 +2,7 @@
 <?eclipse version="3.0"?>
 <plugin>
    <extension-point id="editor_input_adapter" name="EditorInput Adapter" schema="schema/editor_input_adapter.exsd"/>
+   <extension-point id="editor_input_default_adapters" name="EditorInput Default Adapters" schema="schema/editor_input_default_adapters.exsd"/>
    <extension
          point="org.eclipse.ui.startup">
       <startup

--- a/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_adapter.exsd
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_adapter.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="fr.kazejiyu.discord.rpc.integration" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="fr.kazejiyu.discord.rpc.integration" id="editor_input_adapter" name="EditorInput Adapter"/>
+      </appInfo>
+      <documentation>
+         For providing an adapter extracting information from a specific editor in order to show it in Discord.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="adapter"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="adapter">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The adapter that extracts Rich Presence from a specific IEditorInput.
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_default_adapters.exsd
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_default_adapters.exsd
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="fr.kazejiyu.discord.rpc.integration" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="fr.kazejiyu.discord.rpc.integration" id="editor_input_default_adapters" name="EditorInput Default Adapters"/>
+      </appInfo>
+      <documentation>
+         &lt;b&gt;/!\ Internal use only: this extension point is not intended to be used by clients.&lt;/b&gt;&lt;br&gt;
+&lt;br&gt;
+For providing default adapters that extracts information from a specific editor in order to show it in Discord.&lt;br&gt;
+&lt;br&gt;
+If you want to define your own adapters, take a look at the &lt;i&gt;fr.kazejiyu.discord.rpc.integration.editor_input_default_adapters&lt;/i&gt; extension point.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="adapter"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="adapter">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/DiscordIntegrationExtensions.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/DiscordIntegrationExtensions.java
@@ -7,9 +7,16 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.RegistryFactory;
 import org.eclipse.ui.IEditorInput;
 
+/**
+ * Manages plug-in's extensions.
+ * 
+ * @author Emmanuel CHEBBI
+ */
 public class DiscordIntegrationExtensions {
 
 	public static final String EDITOR_INPUT_ADAPTER_EXTENSION_ID = "fr.kazejiyu.discord.rpc.integration.editor_input_adapter";
+
+	public static final String EDITOR_INPUT_DEFAULT_ADAPTER_EXTENSION_ID = "fr.kazejiyu.discord.rpc.integration.editor_input_default_adapters";
 
 	/**
 	 * Returns an adapter able to turn {@code input} into a {@link RichPresence}
@@ -19,14 +26,48 @@ public class DiscordIntegrationExtensions {
 	 * {@value #EDITOR_INPUT_ADAPTER_EXTENSION_ID} extension point.
 	 * 
 	 * @param input
-	 *            The input to turn into a {@code RichPresence} instance. Must not
-	 *            be {@code null}.
+	 *			The input to turn into a {@code RichPresence} instance. 
+	 *          Must not be {@code null}.
 	 * 
 	 * @return an adapter able to handle {@code input}, if any.
 	 */
 	public Optional<EditorInputRichPresence> findAdapterFor(IEditorInput input) {
+		return findAdapterFor(input, EDITOR_INPUT_ADAPTER_EXTENSION_ID);
+	}
+
+	/**
+	 * Returns an adapter able to turn {@code input} into a {@link RichPresence}
+	 * instance.<br>
+	 * <br>
+	 * The adapter is one of the adapters registered to the
+	 * {@value #EDITOR_INPUT_DEFAULT_ADAPTER_EXTENSION_ID} extension point.
+	 * 
+	 * @param input
+	 *            The input to turn into a {@code RichPresence} instance. 
+	 *            Must not be {@code null}.
+	 * 
+	 * @return an adapter able to handle {@code input}, if any.
+	 */
+	public Optional<EditorInputRichPresence> findDefaultAdapterFor(IEditorInput input) {
+		return findAdapterFor(input, EDITOR_INPUT_DEFAULT_ADAPTER_EXTENSION_ID);
+	}
+
+	/**
+	 * Returns an adapter able to turn {@code input} into a {@link RichPresence}
+	 * instance.<br>
+	 * 
+	 * @param input
+	 *			The input to turn into a {@code RichPresence} instance. 
+	 *          Must not be {@code null}.
+	 * @param extensionId
+	 * 			The id of the extension defining the adapters.
+	 * 			Must not be {@code null}.	
+	 * 
+	 * @return an adapter able to handle {@code input}, if any.
+	 */
+	private Optional<EditorInputRichPresence> findAdapterFor(IEditorInput input, String extensionId) {
 		IConfigurationElement[] elements = RegistryFactory.getRegistry()
-				.getConfigurationElementsFor(EDITOR_INPUT_ADAPTER_EXTENSION_ID);
+				.getConfigurationElementsFor(extensionId);
 		
 		for (IConfigurationElement element : elements) {
 			Object extension = createExecutableExtension(element);

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/DiscordIntegrationExtensions.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/DiscordIntegrationExtensions.java
@@ -1,0 +1,61 @@
+package fr.kazejiyu.discord.rpc.integration.extensions;
+
+import java.util.Optional;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.RegistryFactory;
+import org.eclipse.ui.IEditorInput;
+
+public class DiscordIntegrationExtensions {
+
+	public static final String EDITOR_INPUT_ADAPTER_EXTENSION_ID = "fr.kazejiyu.discord.rpc.integration.editor_input_adapter";
+
+	/**
+	 * Returns an adapter able to turn {@code input} into a {@link RichPresence}
+	 * instance.<br>
+	 * <br>
+	 * The adapter is one of the adapters registered to the
+	 * {@value #EDITOR_INPUT_ADAPTER_EXTENSION_ID} extension point.
+	 * 
+	 * @param input
+	 *            The input to turn into a {@code RichPresence} instance. Must not
+	 *            be {@code null}.
+	 * 
+	 * @return an adapter able to handle {@code input}, if any.
+	 */
+	public Optional<EditorInputRichPresence> findAdapterFor(IEditorInput input) {
+		IConfigurationElement[] elements = RegistryFactory.getRegistry()
+				.getConfigurationElementsFor(EDITOR_INPUT_ADAPTER_EXTENSION_ID);
+		
+		for (IConfigurationElement element : elements) {
+			Object extension = createExecutableExtension(element);
+			
+			if (extension instanceof EditorInputRichPresence) {
+				EditorInputRichPresence adapter = (EditorInputRichPresence) extension;
+				
+				if (isAValidAdapter(adapter, input))
+					return Optional.of(adapter);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	/** @return a new instance of {@code element}'s class property if possible, {@code null} otherwise */
+	private Object createExecutableExtension(IConfigurationElement element) {
+		try {
+			return element.createExecutableExtension("class");
+
+		} catch (CoreException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	/** @return whether {@code adapter} can handle {@code input} */
+	private boolean isAValidAdapter(EditorInputRichPresence adapter, IEditorInput input) {
+		return adapter.getExpectedEditorInputClass().isInstance(input);
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/EditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/EditorInputRichPresence.java
@@ -1,0 +1,36 @@
+package fr.kazejiyu.discord.rpc.integration.extensions;
+
+import java.util.Optional;
+
+import org.eclipse.ui.IEditorInput;
+
+import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
+
+/**
+ * Extracts Rich Presence from an {@link IEditorInput}.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public interface EditorInputRichPresence {
+	
+	/**
+	 * Returns the class of the input expected as an argument of {@link #createRichPresence(DiscordIntegrationPreferences, IEditorInput)}.
+	 * @return the class of the input expected as an argument of {@link #createRichPresence(DiscordIntegrationPreferences, IEditorInput)}
+	 */
+	Class<? extends IEditorInput> getExpectedEditorInputClass();
+	
+	/**
+	 * Creates the Rich Presence information to send to Discord.
+	 * 
+	 * @param preferences
+	 * 			User's preferences regarding the information to show in Discord.
+	 * 			Must not be {@code null}.
+	 * @param input
+	 * 			The input of the active editor. 
+	 * 			Must satisfy {@code getExpectedEditorInputClass().isInstance(input) == true}.
+	 * 
+	 * @return the information to show in Discord
+	 */
+	Optional<RichPresence> createRichPresence(DiscordIntegrationPreferences preferences, IEditorInput input);
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/RichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/RichPresence.java
@@ -1,0 +1,30 @@
+package fr.kazejiyu.discord.rpc.integration.extensions;
+
+/**
+ * Provides Discord's Rich Presence informations.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class RichPresence {
+	
+	private String details;
+
+	private String state;
+	
+	public String getDetails() {
+		return details;
+	}
+
+	public void setDetails(String details) {
+		this.details = details;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/impl/UnknownInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/impl/UnknownInputRichPresence.java
@@ -1,0 +1,36 @@
+package fr.kazejiyu.discord.rpc.integration.extensions.impl;
+
+import java.util.Optional;
+
+import org.eclipse.ui.IEditorInput;
+
+import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
+import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.extensions.RichPresence;
+
+/**
+ * Used when no valid adapter can be found for a given {@link IEditorInput}.<br>
+ * <br>
+ * Clear information shown in Discord.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class UnknownInputRichPresence implements EditorInputRichPresence {
+
+	@Override
+	public Class<? extends IEditorInput> getExpectedEditorInputClass() {
+		return IEditorInput.class;
+	}
+
+	@Override
+	public Optional<RichPresence> createRichPresence(DiscordIntegrationPreferences preferences, IEditorInput input) {
+		RichPresence presence = new RichPresence();
+		
+		// TODO Set details & state to empty String as soon as Discord RPC API is fixed
+		presence.setDetails("Unknown file");
+		presence.setState("Unknown project");
+		
+		return Optional.of(presence);
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/impl/package-info.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/impl/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Default implementations for {@link fr.kazejiyu.discord.rpc.integration.extensions.RichPresence RichPresence}
+ * interface.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+package fr.kazejiyu.discord.rpc.integration.extensions.impl;

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/package-info.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Provides interfaces for extensions points.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+package fr.kazejiyu.discord.rpc.integration.extensions;

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
@@ -1,22 +1,21 @@
 package fr.kazejiyu.discord.rpc.integration.listener;
 
-import java.io.File;
-import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.ISelectionListener;
-import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.part.EditorPart;
 
 import fr.kazejiyu.discord.rpc.integration.core.DiscordIntegrationPreferences;
 import fr.kazejiyu.discord.rpc.integration.core.DiscordRpcProxy;
+import fr.kazejiyu.discord.rpc.integration.extensions.DiscordIntegrationExtensions;
+import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.extensions.RichPresence;
 
 /**
  * Notifies {@link DiscordRpcProxy} each time Eclipse's current selection changes.
@@ -29,6 +28,8 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 	private final DiscordRpcProxy rpc = new DiscordRpcProxy();
 	
 	private IWorkbenchPart lastSelectedPart = null;
+	
+	private DiscordIntegrationExtensions extensions = new DiscordIntegrationExtensions();
 
 	/** User's preferences */
 	private static final DiscordIntegrationPreferences preferences = DiscordIntegrationPreferences.INSTANCE;
@@ -41,51 +42,22 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 	@Override
 	public void selectionChanged(IWorkbenchPart part, ISelection selection) {
 		if (!(part instanceof EditorPart) || part.equals(lastSelectedPart))
-				return;
+			return;
 		
+		lastSelectedPart = part;
 		EditorPart editor = (EditorPart) part;
 		
-		// Generic file editor
-		if (editor.getEditorInput() instanceof IFileEditorInput) {
-			IFile inEdition = ((IFileEditorInput) editor.getEditorInput()).getFile();
-			IProject project = inEdition.getProject();
-			
-			String details, state;
-			
-			if (preferences.showsFileName())
-				details = "Editing " + inEdition.getName();
-			else
-				details = "Editing a mysterious file";
-			
-			if (preferences.showsProjectName())
-				state = (project != null) ? "Working on " + project.getName() : "";
-			else
-				state = "Working on a mysterious project";	
-				
-			rpc.setInformations(details, state);
-			lastSelectedPart = part;
+		Optional<EditorInputRichPresence> maybeUserAdapter = extensions.findAdapterFor(editor.getEditorInput());
+		
+		if (maybeUserAdapter.isPresent()) {
+			Optional<RichPresence> maybePresence = maybeUserAdapter.get().createRichPresence(preferences, editor.getEditorInput());
+			maybePresence.ifPresent(forwardToDiscord());
 		}
-		// Also handles Files located outside of the workspace
-		else if (editor.getEditorInput() instanceof IURIEditorInput) {
-			URI inEdition = ((IURIEditorInput) editor.getEditorInput()).getURI();
-			
-			File editedFile = new File(inEdition.getPath());
-			
-			String details, state;
-			
-			if (preferences.showsFileName())
-				details = editedFile.exists() ? "Editing " + editedFile.getName() : "";
-			else
-				details = "Editing a mysterious file";
-			
-			if (preferences.showsProjectName())
-				state = "Unknown project";
-			else
-				state = "Working on a mysterious project";
-				
-			rpc.setInformations(details, state);
-			lastSelectedPart = part;
-		}
+	}
+	
+	/** @return a consumer that takes a {@code RichPresence} and sends its information to Discord */
+	private Consumer<RichPresence> forwardToDiscord() {
+		return presence -> rpc.setInformations(presence.getDetails(), presence.getState()); 
 	}
 	
 	@Override


### PR DESCRIPTION
See [related user story](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/us/21?kanban-status=1585801).

Provide an extension point that can be used to specify the information to display according to a specific text editor.