### PR TITLE
Show elapsed time in Discord

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -53,6 +53,7 @@ public class DefaultFileEditorInputRichPresence implements EditorInputRichPresen
 		
 		presence.setDetails(detailsOf(preferences, fileInput));
 		presence.setState(stateOf(preferences, fileInput));
+		presence.setProject(projectOf(preferences, fileInput));
 		
 		return Optional.of(presence);
 	}
@@ -74,6 +75,11 @@ public class DefaultFileEditorInputRichPresence implements EditorInputRichPresen
 		IProject project = inEdition.getProject();
 		
 		return "Working on " + ((project != null) ? project.getName() : "an unknown project");
+	}
+
+	private IProject projectOf(DiscordIntegrationPreferences preferences, IFileEditorInput input) {
+		IFile inEdition = input.getFile();
+		return inEdition.getProject();
 	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            class="fr.kazejiyu.discord.rpc.integration.ui.preferences.DiscordIntegrationPreferences"
+            class="fr.kazejiyu.discord.rpc.integration.ui.preferences.DiscordIntegrationPreferencesPage"
             id="fr.kazejiyu.discord.rpc.integration.ui.preferences.root"
             name="Discord Integration">
       </page>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferences.java
@@ -3,6 +3,7 @@ package fr.kazejiyu.discord.rpc.integration.ui.preferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
@@ -23,6 +24,13 @@ public class DiscordIntegrationPreferences extends FieldEditorPreferencePage imp
     public void createFieldEditors() {
         addField(new BooleanFieldEditor("SHOW_FILE_NAME", "Show &file's name", getFieldEditorParent()));
         addField(new BooleanFieldEditor("SHOW_PROJECT_NAME", "Show &project's name", getFieldEditorParent()));
+        
+        addField(new RadioGroupFieldEditor("RESET_ELAPSED_TIME", "&Reset elapsed time:", 3,
+                new String[][] { { "On startup", "RESET_ELAPSED_TIME_ON_STARTUP" }, 
+        						 { "On new project", "RESET_ELAPSED_TIME_ON_NEW_PROJECT" },
+                				 { "On new file", "RESET_ELAPSED_TIME_ON_NEW_FILE" } },
+				getFieldEditorParent()
+		));
     }
     
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
@@ -11,6 +11,7 @@ public class DiscordIntegrationPreferencesInitializer extends AbstractPreference
 		
         store.setDefault("SHOW_FILE_NAME", true);
         store.setDefault("SHOW_PROJECT_NAME", true);
+        store.setDefault("RESET_ELAPSED_TIME", "RESET_ELAPSED_TIME_ON_PROJECT");
 	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesPage.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesPage.java
@@ -8,9 +8,9 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
-public class DiscordIntegrationPreferences extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class DiscordIntegrationPreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-	public DiscordIntegrationPreferences() {
+	public DiscordIntegrationPreferencesPage() {
 		super(GRID);
 	}
 

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordIntegrationPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordIntegrationPreferences.java
@@ -24,5 +24,23 @@ public enum DiscordIntegrationPreferences {
 		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
 		return s.getBoolean("SHOW_PROJECT_NAME");
 	}
+	
+	/** @return whether the name of the current project should be shown in Discord */
+	public boolean resetsElapsedTimeOnStartup() {
+		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
+		return s.getString("RESET_ELAPSED_TIME").equals("RESET_ELAPSED_TIME_ON_STARTUP");
+	}
+	
+	/** @return whether the name of the current project should be shown in Discord */
+	public boolean resetsElapsedTimeOnNewProject() {
+		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
+		return s.getString("RESET_ELAPSED_TIME").equals("RESET_ELAPSED_TIME_ON_NEW_PROJECT");
+	}
+	
+	/** @return whether the name of the current project should be shown in Discord */
+	public boolean resetsElapsedTimeOnNewFile() {
+		IPreferenceStore s = new ScopedPreferenceStore(InstanceScope.INSTANCE, "fr.kazejiyu.discord.rpc.integration.preferences.store");
+		return s.getString("RESET_ELAPSED_TIME").equals("RESET_ELAPSED_TIME_ON_NEW_FILE");
+	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordRpcProxy.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordRpcProxy.java
@@ -17,7 +17,7 @@ import com.github.psnrigner.discordrpcjava.ErrorCode;
 public class DiscordRpcProxy {
 	
 	/** Identifies the Eclipse Integration Discord app */
-	private static final String applicationId = "413038514616139786";
+	private static final String APPLICATION_ID = "413038514616139786";
 	
 	/** The delay before shutting down the connection with Discord, in seconds */
 	private static final long TIMEOUT_BEFORE_SHUTTING_DOWN = 5000;
@@ -25,11 +25,13 @@ public class DiscordRpcProxy {
 	/** Helps to close the connection to Discord after a certain delay */
 	private final Timer timer = new Timer("Shutdown Discord RPC connection");
 	
+	private final long timeOnStartup = System.currentTimeMillis() / 1000;
+	
 	/**
 	 * Initializes the connection to Discord session.
 	 */
 	public void initialize() {
-		
+
 	}
 
 	/**
@@ -39,19 +41,20 @@ public class DiscordRpcProxy {
 	 * 			The new details. Must not be {@code null}.
 	 */
 	public void setDetails(String details) {
-		setInformations(details, "");
+		setInformations(details, "", System.currentTimeMillis() / 1000);
 	}
 
-	public void setInformations(String details, String state) {
+	public void setInformations(String details, String state, long elapsedTime) {
 		// NOTE Currently, API is broken and connection must be re-created at each modification
 		// see https://github.com/PSNRigner/discord-rpc-java/issues/13
 		
 		DiscordRpc rpc = new DiscordRpc();
-		rpc.init(applicationId, createDiscordEventHandler(), true);
+		rpc.init(APPLICATION_ID, createDiscordEventHandler(), true);
 		
 		DiscordRichPresence presence = new DiscordRichPresence();
 		presence.setState(state);
 		presence.setDetails(details);
+		presence.setStartTimestamp(elapsedTime == 0 ? timeOnStartup : elapsedTime);
 		
 		rpc.updatePresence(presence);
 		
@@ -89,7 +92,7 @@ public class DiscordRpcProxy {
 	}
 	
 	public void setDefault() {
-		setInformations("Browsing IDE", "No project");
+		setInformations("Browsing IDE", "No project", System.currentTimeMillis());
 	}
 	
 	/** Creates an handler listening for Discord events. Not used at the moment. */

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/RichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/RichPresence.java
@@ -1,5 +1,7 @@
 package fr.kazejiyu.discord.rpc.integration.extensions;
 
+import org.eclipse.core.resources.IProject;
+
 /**
  * Provides Discord's Rich Presence informations.
  * 
@@ -10,6 +12,8 @@ public class RichPresence {
 	private String details;
 
 	private String state;
+	
+	private IProject project;
 	
 	public String getDetails() {
 		return details;
@@ -25,6 +29,14 @@ public class RichPresence {
 
 	public void setState(String state) {
 		this.state = state;
+	}
+	
+	public IProject getProject() {
+		return project;
+	}
+
+	public void setProject(IProject project) {
+		this.project = project;
 	}
 
 }


### PR DESCRIPTION
See [related user story](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/us/25?kanban-status=1585799)

Show time spent working on Eclipse in Discord.

Preferences page has been enriched with a new field making the user able to choose when the elapsed time should be reset:

- on Eclipse startup,
- on new project,
- on new file.