### PR TITLE
Display language icons in Discord

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -9,6 +9,8 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.adapters;
 
+import static fr.kazejiyu.discord.rpc.integration.adapters.LanguageLabel.labelOf;
+
 import java.util.Optional;
 
 import org.eclipse.core.resources.IFile;
@@ -103,11 +105,7 @@ public class DefaultFileEditorInputRichPresence implements EditorInputRichPresen
 			return "";
 		
 		Language language = Language.fromFileName(file.getName());
-		
-		if (language == Language.UNKNOWN)
-			return "";
-		
-		return "Programming in " + language.getName();
+		return labelOf(language, file.getName());
 	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -95,14 +95,14 @@ public class DefaultFileEditorInputRichPresence implements EditorInputRichPresen
 		if (! preferences.showsFileName())
 			return Language.UNKNOWN;
 		
-		return Language.fromFileExtension(file.getName());
+		return Language.fromFileName(file.getName());
 	}
 
 	private String largeImageTextOf(UserPreferences preferences, IFile file) {
 		if (! preferences.showsFileName())
 			return "";
 		
-		Language language = Language.fromFileExtension(file.getName());
+		Language language = Language.fromFileName(file.getName());
 		
 		if (language == Language.UNKNOWN)
 			return "";

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
@@ -98,14 +98,14 @@ public class DefaultURIEditorInputRichPresence implements EditorInputRichPresenc
 		if (! preferences.showsFileName())
 			return Language.UNKNOWN;
 		
-		return Language.fromFileExtension(file.getName());
+		return Language.fromFileName(file.getName());
 	}
 
 	private String largeImageTextOf(UserPreferences preferences, File file) {
 		if (! preferences.showsFileName())
 			return "";
 		
-		Language language = Language.fromFileExtension(file.getName());
+		Language language = Language.fromFileName(file.getName());
 		
 		if (language == Language.UNKNOWN)
 			return "";

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
@@ -9,6 +9,8 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.adapters;
 
+import static fr.kazejiyu.discord.rpc.integration.adapters.LanguageLabel.labelOf;
+
 import java.io.File;
 import java.net.URI;
 import java.util.Optional;
@@ -106,11 +108,7 @@ public class DefaultURIEditorInputRichPresence implements EditorInputRichPresenc
 			return "";
 		
 		Language language = Language.fromFileName(file.getName());
-		
-		if (language == Language.UNKNOWN)
-			return "";
-		
-		return "Programming in " + language.getName();
+		return labelOf(language, file.getName());
 	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultURIEditorInputRichPresence.java
@@ -19,7 +19,9 @@ import org.eclipse.ui.ide.FileStoreEditorInput;
 
 import fr.kazejiyu.discord.rpc.integration.core.RichPresence;
 import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
 import fr.kazejiyu.discord.rpc.integration.settings.GlobalPreferences;
+import fr.kazejiyu.discord.rpc.integration.settings.UserPreferences;
 
 /**
  * Default implementation of {@link EditorInputRichPresence}.<br>
@@ -65,30 +67,50 @@ public class DefaultURIEditorInputRichPresence implements EditorInputRichPresenc
 			throw new IllegalArgumentException("input must be an instance of " + IURIEditorInput.class);
 		
 		IURIEditorInput uriInput = (IURIEditorInput) input;
+		URI fileURI = uriInput.getURI();
+		File file = new File(fileURI.getPath());
 		
 		RichPresence presence = new RichPresence();
 		
-		presence.withDetails(detailsOf(preferences, uriInput));
-		presence.withState(stateOf(preferences, uriInput));
+		presence.withDetails(detailsOf(preferences, file));
+		presence.withState(stateOf(preferences));
+		presence.withLanguage(languageOf(preferences, file));
+		presence.withLargeImageText(largeImageTextOf(preferences, file));
 		
 		return Optional.of(presence);
 	}
 
-	private String detailsOf(GlobalPreferences preferences, IURIEditorInput input) {
+	private String detailsOf(GlobalPreferences preferences, File file) {
 		if (! preferences.showsFileName())
 			return "";
 		
-		URI inEdition = input.getURI();
-		File editedFile = new File(inEdition.getPath());
-		
-		return "Editing " + editedFile.getName();
+		return "Editing " + file.getName();
 	}
 
-	private String stateOf(GlobalPreferences preferences, IURIEditorInput input) {
+	private String stateOf(GlobalPreferences preferences) {
 		if (! preferences.showsProjectName())
 			return "";
 		
 		return "Unknown project";
+	}
+
+	private Language languageOf(UserPreferences preferences, File file) {
+		if (! preferences.showsFileName())
+			return Language.UNKNOWN;
+		
+		return Language.fromFileExtension(file.getName());
+	}
+
+	private String largeImageTextOf(UserPreferences preferences, File file) {
+		if (! preferences.showsFileName())
+			return "";
+		
+		Language language = Language.fromFileExtension(file.getName());
+		
+		if (language == Language.UNKNOWN)
+			return "";
+		
+		return "Programming in " + language.getName();
 	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/LanguageLabel.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/LanguageLabel.java
@@ -1,0 +1,47 @@
+package fr.kazejiyu.discord.rpc.integration.adapters;
+
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.BINARY;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.DOCKER;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.GIT;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.SCALA;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.TERMINAL;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.TEXT;
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.UNKNOWN;
+
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
+
+/**
+ * Creates a label for a given {@link Language}.
+ * 
+ * @author Emmanuel CHEBBI
+ *
+ * TODO [Refactor] Consider turning Language into an OO architecture to get rid of this class
+ */
+class LanguageLabel {
+	
+	static String labelOf(Language language, String fileName) {
+		if (language == UNKNOWN)
+			return "";
+		
+		if (language == BINARY)
+			return "Binary file";
+		
+		if (language == DOCKER)
+			return "Configuring Docker image";
+		
+		if (language == GIT)
+			return "Configuring Git";
+		
+		if (language == SCALA && fileName.endsWith(".sbt"))
+			return "Configuring SBT build";
+		
+		if (language == TERMINAL)
+			return "Configuring an OS script";
+		
+		if (language == TEXT)
+			return "Text file";
+		
+		return "Programming in " + language.getName();
+	}
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesInitializer.java
@@ -23,6 +23,7 @@ public class DiscordIntegrationPreferencesInitializer extends AbstractPreference
         store.setDefault(SHOW_FILE_NAME.property(), true);
         store.setDefault(SHOW_PROJECT_NAME.property(), true);
         store.setDefault(SHOW_ELAPSED_TIME.property(), true);
+        store.setDefault(SHOW_LANGUAGE_ICON.property(), true);
         store.setDefault(RESET_ELAPSED_TIME.property(), RESET_ELAPSED_TIME_ON_NEW_PROJECT.property());
 	}
 

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesPage.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/DiscordIntegrationPreferencesPage.java
@@ -12,6 +12,7 @@ package fr.kazejiyu.discord.rpc.integration.ui.preferences;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -44,10 +45,12 @@ public class DiscordIntegrationPreferencesPage extends FieldEditorPreferencePage
         BooleanFieldEditor showFileName = new BooleanFieldEditor(SHOW_FILE_NAME.property(), "Show &file name", group.getFieldEditorParent());
         BooleanFieldEditor showProjectName = new BooleanFieldEditor(SHOW_PROJECT_NAME.property(), "Show &project name", group.getFieldEditorParent());
         BooleanFieldEditor showElapsedTime = new BooleanFieldEditor(SHOW_ELAPSED_TIME.property(), "Show &elapsed time", group.getFieldEditorParent());
+        BooleanFieldEditor showLanguageIcon = new BooleanFieldEditor(SHOW_LANGUAGE_ICON.property(), "Show &language icon", group.getFieldEditorParent());
         
         group.addFieldEditor(showFileName);
         group.addFieldEditor(showProjectName);
         group.addFieldEditor(showElapsedTime);
+        group.addFieldEditor(showLanguageIcon);
         
         addField(group);
         

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
@@ -16,6 +16,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.USE_PROJECT_SETTINGS;
 
 import org.eclipse.core.resources.IProject;
@@ -50,6 +51,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 	private Button showProjectName;
 	private Button showFileName;
 	private Button showElapsedTime;
+	private Button showLanguageIcon;
 	
 	private Button resetOnStartup;
 	private Button resetOnProjectSelection;
@@ -102,6 +104,8 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			resource.setPersistentProperty(SHOW_PROJECT_NAME.qualifiedName(), "true");
 		if (resource.getPersistentProperty(SHOW_FILE_NAME.qualifiedName()) == null)
 			resource.setPersistentProperty(SHOW_FILE_NAME.qualifiedName(), "true");
+		if (resource.getPersistentProperty(SHOW_LANGUAGE_ICON.qualifiedName()) == null)
+			resource.setPersistentProperty(SHOW_LANGUAGE_ICON.qualifiedName(), "true");
 		if (resource.getPersistentProperty(SHOW_ELAPSED_TIME.qualifiedName()) == null)
 			resource.setPersistentProperty(SHOW_ELAPSED_TIME.qualifiedName(), "true");
 		if (resource.getPersistentProperty(RESET_ELAPSED_TIME.qualifiedName()) == null)
@@ -114,6 +118,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 		showProjectName.setSelection(true);
 		showFileName.setSelection(true);
 		showElapsedTime.setSelection(true);
+		showLanguageIcon.setSelection(true);
 		resetOnStartup.setSelection(false);
 		resetOnProjectSelection.setSelection(true);
 		resetOnFileSelection.setSelection(false);
@@ -128,6 +133,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			project.setPersistentProperty(SHOW_PROJECT_NAME.qualifiedName(), showProjectName.getSelection() + "");
 			project.setPersistentProperty(SHOW_FILE_NAME.qualifiedName(), showFileName.getSelection() + "");
 			project.setPersistentProperty(SHOW_ELAPSED_TIME.qualifiedName(), showElapsedTime.getSelection() + "");
+			project.setPersistentProperty(SHOW_LANGUAGE_ICON.qualifiedName(), showLanguageIcon.getSelection() + "");
 			
 			if (resetOnStartup.getSelection())
 				project.setPersistentProperty(RESET_ELAPSED_TIME.qualifiedName(), RESET_ELAPSED_TIME_ON_STARTUP.property());
@@ -140,6 +146,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			preferences.putBoolean(SHOW_PROJECT_NAME.property(), showProjectName.getSelection());
 			preferences.putBoolean(SHOW_FILE_NAME.property(), showFileName.getSelection());
 			preferences.putBoolean(SHOW_ELAPSED_TIME.property(), showElapsedTime.getSelection());
+			preferences.putBoolean(SHOW_LANGUAGE_ICON.property(), showLanguageIcon.getSelection());
 
 			if (resetOnStartup.getSelection())
 				preferences.put(RESET_ELAPSED_TIME.property(), RESET_ELAPSED_TIME_ON_STARTUP.property());
@@ -222,6 +229,14 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 						project.getPersistentProperty(SHOW_ELAPSED_TIME.qualifiedName())
 				)
 		);
+
+		showLanguageIcon = new Button(privacy, SWT.CHECK);
+		showLanguageIcon.setText("Show language icon");
+		showLanguageIcon.setSelection(
+				Boolean.parseBoolean(
+						project.getPersistentProperty(SHOW_LANGUAGE_ICON.qualifiedName())
+				)
+		);
 	}
 	
 	private void addResetElapsedTimeSection(Composite parent) throws CoreException {
@@ -259,6 +274,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 				showProjectName.setEnabled(true);
 				showFileName.setEnabled(true);
 				showElapsedTime.setEnabled(true);
+				showLanguageIcon.setEnabled(true);
 				disableResetGroupIfNeeded();
 			}
 			
@@ -277,6 +293,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 				showProjectName.setEnabled(false);
 				showFileName.setEnabled(false);
 				showElapsedTime.setEnabled(false);
+				showLanguageIcon.setEnabled(false);
 				resetOnStartup.setEnabled(false);
 				resetOnProjectSelection.setEnabled(false);
 				resetOnFileSelection.setEnabled(false);
@@ -325,6 +342,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			showProjectName.setEnabled(false);
 			showFileName.setEnabled(false);
 			showElapsedTime.setEnabled(false);
+			showLanguageIcon.setEnabled(false);
 			resetOnStartup.setEnabled(false);
 			resetOnProjectSelection.setEnabled(false);
 			resetOnFileSelection.setEnabled(false);

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -13,5 +13,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: fr.kazejiyu.discord.rpc.integration.core,
  fr.kazejiyu.discord.rpc.integration.extensions,
+ fr.kazejiyu.discord.rpc.integration.languages,
  fr.kazejiyu.discord.rpc.integration.settings
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/Activator.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/Activator.java
@@ -14,6 +14,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 
 import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;
@@ -58,6 +59,7 @@ public class Activator extends AbstractUIPlugin implements IStartup {
 		getPreferenceStore().setDefault(SHOW_FILE_NAME.property(), true);
 		getPreferenceStore().setDefault(SHOW_PROJECT_NAME.property(), true);
 		getPreferenceStore().setDefault(SHOW_ELAPSED_TIME.property(), true);
+		getPreferenceStore().setDefault(SHOW_LANGUAGE_ICON.property(), true);
 		getPreferenceStore().setDefault(RESET_ELAPSED_TIME.property(), RESET_ELAPSED_TIME_ON_NEW_PROJECT.property());
 	}
 	

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordRpcProxy.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/DiscordRpcProxy.java
@@ -18,6 +18,8 @@ import com.github.psnrigner.discordrpcjava.DiscordRichPresence;
 import com.github.psnrigner.discordrpcjava.DiscordRpc;
 import com.github.psnrigner.discordrpcjava.ErrorCode;
 
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
+
 /**
  * A proxy able to communicate with Discord.<br>
  * <br>
@@ -67,6 +69,8 @@ public class DiscordRpcProxy {
 		rp.getState().ifPresent(presence::setState);
 		rp.getDetails().ifPresent(presence::setDetails);
 		rp.getStartTimestamp().ifPresent(presence::setStartTimestamp);
+		rp.getLargeImageText().ifPresent(presence::setLargeImageText);
+		rp.getLanguage().map(Language::getKey).ifPresent(presence::setLargeImageKey);
 		
 		rpc.updatePresence(presence);
 		

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/RichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/core/RichPresence.java
@@ -9,9 +9,13 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.core;
 
+import static fr.kazejiyu.discord.rpc.integration.languages.Language.UNKNOWN;
+
 import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
+
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
 
 /**
  * Defines the elements to show in Discord.
@@ -25,6 +29,10 @@ public class RichPresence {
 	private String state;
 	
 	private long startTimestamp;
+	
+	private Language language;
+	
+	private String largeImageText;
 	
 	private IProject project;
 
@@ -46,6 +54,8 @@ public class RichPresence {
 		this.details = origin.details;
 		this.state = origin.state;
 		this.startTimestamp = origin.startTimestamp;
+		this.language = origin.language;
+		this.largeImageText = origin.largeImageText;
 		this.project = origin.project;
 	}
 	
@@ -59,6 +69,8 @@ public class RichPresence {
 		withDetails("");
 		withState("");
 		withStartTimestamp(-1l);
+		withLanguage(UNKNOWN);
+		withLargeImageText("");
 		return this;
 	}
 	
@@ -158,6 +170,60 @@ public class RichPresence {
 	 */
 	public RichPresence withCurrentTimestamp() {
 		return withStartTimestamp(System.currentTimeMillis() / 1000);
+	}
+	
+	/**
+	 * Returns the language of the active file, if known.
+	 * @return the language of the active file, if known
+	 */
+	public Optional<Language> getLanguage() {
+		if (language == null || language == UNKNOWN)
+			return Optional.empty();
+		return Optional.of(language);
+	}
+
+	/**
+	 * Sets the language of the active file. Defines the large icon to show in Discord.<br>
+	 * <br>
+	 * If the argument is {@link Language.UNKNOWN}, it is considered as
+	 * no language and no icon will be shown in Discord.
+	 * 
+	 * @param language
+	 * 			The language of the active file.
+	 * 
+	 * @return the current instance, enabling method chaining
+	 */
+	
+	public RichPresence withLanguage(Language language) {
+		this.language = language;
+		return this;
+	}
+	
+	/**
+	 * Returns the text to show when hovering the large icon, if any.
+	 * @return the text to show when hovering the large icon, if any
+	 */
+	public Optional<String> getLargeImageText() {
+		if (largeImageText == null || largeImageText.isEmpty())
+			return Optional.empty();
+		return Optional.of(largeImageText);
+	}
+
+	/**
+	 * Sets the text to show when hovering the large icon in Discord.<br>
+	 * <br>
+	 * If the argument is either {@code null} or an empty String, it is considered as
+	 * no text won't be sent to Discord.
+	 * 
+	 * @param hover
+	 * 			The text to show when hovering the large icon in Discord.
+	 * 
+	 * @return the current instance, enabling method chaining
+	 */
+	
+	public RichPresence withLargeImageText(String hover) {
+		this.largeImageText = hover;
+		return this;
 	}
 	
 	public Optional<IProject> getProject() {

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
@@ -19,6 +19,8 @@ import java.util.List;
  * Programming languages handled by the plug-in.
  * 
  * @author Emmanuel CHEBBI
+ * 
+ * TODO [Refactor] Consider using an OO architecture to benefit from polymorphism
  */
 public enum Language {
 	

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
@@ -1,47 +1,120 @@
+/*********************************************************************
+* Copyright (c) 2018 Emmanuel CHEBBI
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.languages;
 
-import java.util.Arrays;
-import java.util.Collection;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Programming languages handled by the plug-in.
+ * 
+ * @author Emmanuel CHEBBI
+ */
 public enum Language {
 	
 	UNKNOWN("", ""),
 	
 	ADA("ada", "Ada", "ada"),
+	BINARY("binary", "Binary", "bin"),
 	BOO("boo", "Boo", "boo"),
 	CLOJURE("clojure", "Clojure", "clj"),
 	COBOL("cobol", "Cobol", "cob", "cbl", "cpy"),
 	CPP("cpp", "C++", "cpp", "hpp"),
 	CRYSTAL("crystal", "Crystal", "cr"),
 	CSS("css3", "CSS", "css"),
+	CSHARP("csharp", "C#", "cs"),
+	DART("dart", "Dart", "dart"),
+	DOCKER("docker", "Docker", emptyList(), asList("Dockerfile")),
+	FORTRAN("fortran", "Fortran", "f", "for"),
+	FORTRAN90("fortran", "Fortran 90", "f90"),
+	FORTRAN95("fortran", "Fortran 95", "f95"),
+	FORTRAN03("fortran", "Fortran 2003", "f03"),
 	GIT("git", "Git", "git", "gitignore"),
+	GO("go", "Go", "go"),
+	GRADLE("gradle", "Gradle", "gradle"),
+	GROOVY("groovy", "Groovy", "groovy", "gvy", "gy", "gsh"),
+	HASKELL("haskell", "Haskell", "hs"),
 	HTML("html5", "HTML", "html"),
 	JAVA("java", "Java", "java"),
 	JAVASCRIPT("js", "JavaScript", "js"),
+	KOTLIN("kotlin", "Kotlin", "kt", "ktm", "kts"),
+	LATEX("bibtex", "LaTeX", "tex"),
+	LISP("lisp", "Lisp", "lisp", "lsp"),
+	LUA("lua", "Lua", "lua"),
 	MARKDOWN("markdown", "Markdown", "markdown", "mdown", "md"),
-	SCALA("scala", "Scala", "scala", "sbt");
+	OCAML("ocaml", "OCaml", "ml", "mli"),
+	PASCAL("pascal", "Pascal", "pas"),
+	PHP("php", "PHP", "php"),
+	PROLOG("prolog", "Prolog", "pro", "pl"),
+	PYTHON("python", "Python", "py"),
+	R("r", "R", "r"),
+	RUBY("ruby", "Ruby", "rb"),
+	RUST("rust", "Rust", "rs", "rlib"),
+	SCALA("scala", "Scala", "scala", "sbt"),
+	SQL("sql", "SQL", "sql"),
+	SWIFT("swift", "Swift", "swift"),
+	TERMINAL("terminal", "OS Scripting Language", "sh", "bash", "ksh"),
+	TEXT("text", "Text", "txt"),
+	TYPESCRIPT("ts", "TypeScript", "ts");
 	
+	/** Identifies the icon to display in Discord */
 	private final String key;
 	
+	/** Human-readable name of the language */
 	private final String name;
 	
+	/** Used for languages using on file extension (.cpp, .xml, .json, ...) */
 	private final Collection<String> extensions;
 	
+	/** Used for languages using file name (Dockerfile, pom.xml, ...) */
+	private final Collection<String> fileNames;
+	
 	private Language(String key, String name, String... extensions) {
-		this.key = key;
-		this.name = name;
-		this.extensions = Arrays.asList(extensions);
+		this(key, name, asList(extensions), emptyList());
 	}
 	
+	private Language(String key, String name, List<String> extensions, List<String> fileNames) {
+		this.key = key;
+		this.name = name;
+		this.extensions = extensions;
+		this.fileNames = fileNames;
+	}
+	
+	/** @return the Discord key identifying language's icon */
 	public String getKey() {
 		return this.key;
 	}
 	
+	/** @return the name of the language */
 	public String getName() {
 		return this.name;
 	}
 	
-	public static Language fromFileExtension(String fileName) {
+	/**
+	 * Returns the language corresponding to the given file name.<br>
+	 * <br>
+	 * If no language can be found, {@link #UNKNOWN} is returned.
+	 *  
+	 * @param fileName
+	 * 			The name of the file which language is looked for.
+	 * 
+	 * @return the language corresponding to the given file name
+	 */
+	public static Language fromFileName(String fileName) {
+		for (Language language : values())
+			if (language.fileNames.contains(fileName))
+				return language;
+		
 		String extension = extensionOf(fileName);
 		
 		if (extension.isEmpty())
@@ -54,6 +127,7 @@ public enum Language {
 		return UNKNOWN;
 	}
 
+	/** @return the extension, without the final dot, of {@code fileName} */
 	private static String extensionOf(String fileName) {
 		int dotIndex = fileName.lastIndexOf('.');
 		

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
@@ -1,0 +1,67 @@
+package fr.kazejiyu.discord.rpc.integration.languages;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public enum Language {
+	
+	UNKNOWN("", ""),
+	
+	ADA("ada", "Ada", "ada"),
+	BOO("boo", "Boo", "boo"),
+	CLOJURE("clojure", "Clojure", "clj"),
+	COBOL("cobol", "Cobol", "cob", "cbl", "cpy"),
+	CPP("cpp", "C++", "cpp", "hpp"),
+	CRYSTAL("crystal", "Crystal", "cr"),
+	CSS("css3", "CSS", "css"),
+	GIT("git", "Git", "git", "gitignore"),
+	HTML("html5", "HTML", "html"),
+	JAVA("java", "Java", "java"),
+	JAVASCRIPT("js", "JavaScript", "js"),
+	MARKDOWN("markdown", "Markdown", "markdown", "mdown", "md"),
+	SCALA("scala", "Scala", "scala", "sbt");
+	
+	private final String key;
+	
+	private final String name;
+	
+	private final Collection<String> extensions;
+	
+	private Language(String key, String name, String... extensions) {
+		this.key = key;
+		this.name = name;
+		this.extensions = Arrays.asList(extensions);
+	}
+	
+	public String getKey() {
+		return this.key;
+	}
+	
+	public String getName() {
+		return this.name;
+	}
+	
+	public static Language fromFileExtension(String fileName) {
+		String extension = extensionOf(fileName);
+		
+		if (extension.isEmpty())
+			return UNKNOWN;
+		
+		for (Language language : values())
+			if (language.extensions.contains(extension))
+				return language;
+		
+		return UNKNOWN;
+	}
+
+	private static String extensionOf(String fileName) {
+		int dotIndex = fileName.lastIndexOf('.');
+		
+		if (dotIndex < 0 || fileName.length() <= dotIndex + 1)
+			return "";
+		
+		String extension = fileName.substring(dotIndex + 1);
+		extension = extension.toLowerCase();
+		return extension;
+	}
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/package-info.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * 
+ */
+/**
+ * @author Kaze
+ *
+ */
+package fr.kazejiyu.discord.rpc.integration.languages;

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/NotifyDiscordRpcOnSelection.java
@@ -29,6 +29,7 @@ import fr.kazejiyu.discord.rpc.integration.core.RichPresence;
 import fr.kazejiyu.discord.rpc.integration.extensions.DiscordIntegrationExtensions;
 import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence;
 import fr.kazejiyu.discord.rpc.integration.extensions.impl.UnknownInputRichPresence;
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
 import fr.kazejiyu.discord.rpc.integration.settings.GlobalPreferences;
 import fr.kazejiyu.discord.rpc.integration.settings.ProjectPreferences;
 import fr.kazejiyu.discord.rpc.integration.settings.SettingChangeListener;
@@ -116,6 +117,7 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 		
 		Optional<RichPresence> maybePresence = adapter.createRichPresence(preferences, editor.getEditorInput());
 		maybePresence.map(withStartTimeStamp())
+					 .map(withLanguageIcon())
 					 .map(listeningForChangesInProjectPreferences())
 					 .ifPresent(discord::show);
 		
@@ -147,6 +149,18 @@ public class NotifyDiscordRpcOnSelection implements ISelectionListener, IPartLis
 			
 			// last possible case: the time starts on startup
 			return presence.withStartTimestamp(timeOnStartup);
+		};
+	}
+	
+	/** Removes presence's language if the user do not want to show it. */
+	private Function<RichPresence, RichPresence> withLanguageIcon() {
+		return presence -> {
+			UserPreferences prefs = preferences.getApplicablePreferencesFor(presence.getProject().orElse(null));
+			
+			if (! prefs.showsLanguageIcon())
+				return presence.withLanguage(Language.UNKNOWN);
+			
+			return presence;
 		};
 	}
 	

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/RunOnSettingChange.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/RunOnSettingChange.java
@@ -39,6 +39,11 @@ class RunOnSettingChange implements SettingChangeListener {
 	public void projectNameVisibilityChanged(boolean isVisible) {
 		updateDiscord.run();
 	}
+	
+	@Override
+	public void languageIconVisibilityChanged(boolean isVisible) {
+		updateDiscord.run();
+	}
 
 	@Override
 	public void elapsedTimeVisibilityChanged(boolean isVisible) {

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferences.java
@@ -16,6 +16,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -68,6 +69,11 @@ public class GlobalPreferences implements UserPreferences {
 	@Override
 	public boolean showsElapsedTime() {
 		return store.getBoolean(SHOW_ELAPSED_TIME.property());
+	}
+	
+	@Override
+	public boolean showsLanguageIcon() {
+		return store.getBoolean(SHOW_LANGUAGE_ICON.property());
 	}
 	
 	@Override

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferencesListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferencesListener.java
@@ -16,6 +16,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.fromProperty;
 import static java.util.Objects.requireNonNull;
 
@@ -56,6 +57,7 @@ public class GlobalPreferencesListener implements IPropertyChangeListener {
 		events.put(SHOW_FILE_NAME.property(), (event, listener) -> listener.fileNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_PROJECT_NAME.property(), (event, listener) -> listener.projectNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
+		events.put(SHOW_LANGUAGE_ICON.property(), (event, listener) -> listener.languageIconVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(RESET_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeResetMomentChanged(toMoment(event.getOldValue()), toMoment(event.getNewValue())));
 	}
 	

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferences.java
@@ -15,6 +15,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_STARTUP;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.USE_PROJECT_SETTINGS;
 import static java.util.Objects.requireNonNull;
@@ -80,6 +81,11 @@ public class ProjectPreferences implements UserPreferences {
 	@Override
 	public boolean showsElapsedTime() {
 		return preferences.getBoolean(SHOW_ELAPSED_TIME.property(), true);
+	}
+	
+	@Override
+	public boolean showsLanguageIcon() {
+		return preferences.getBoolean(SHOW_LANGUAGE_ICON.property(), true);
 	}
 	
 	@Override

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferencesListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferencesListener.java
@@ -17,6 +17,7 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.fromProperty;
 import static java.util.Objects.requireNonNull;
 
@@ -55,6 +56,7 @@ public class ProjectPreferencesListener implements IPreferenceChangeListener {
 		events.put(SHOW_FILE_NAME.property(), (event, listener) -> listener.fileNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_PROJECT_NAME.property(), (event, listener) -> listener.projectNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
+		events.put(SHOW_LANGUAGE_ICON.property(), (event, listener) -> listener.languageIconVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(RESET_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeResetMomentChanged(toMoment(event.getOldValue()), toMoment(event.getNewValue())));
 		events.put(USE_PROJECT_SETTINGS.property(), (event, listener) -> listener.useProjectProperties(Boolean.parseBoolean((String) event.getNewValue())));
 	}

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/SettingChangeListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/SettingChangeListener.java
@@ -44,6 +44,15 @@ public interface SettingChangeListener {
 	void projectNameVisibilityChanged(boolean isVisible);
 
 	/**
+	 * Called when the user changes language icon's visibility.
+	 * 
+	 * @param isVisible
+	 * 			{@code true} if the user wants to show the language icon,
+	 * 			{@code false} otherwise.
+	 */
+	void languageIconVisibilityChanged(boolean isVisible);
+
+	/**
 	 * Called when the user changes elapsed time's visibility.
 	 * 
 	 * @param isVisible

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/Settings.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/Settings.java
@@ -37,6 +37,8 @@ public enum Settings {
 	
 	RESET_ELAPSED_TIME_ON_NEW_FILE("RESET_ELAPSED_TIME_ON_NEW_FILE"),
 	
+	SHOW_LANGUAGE_ICON("SHOW_LANGUAGE_ICON"),
+	
 	USE_PROJECT_SETTINGS("USE_PROJECT_SETTINGS");
 	
 	/** A key identifying the setting */

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/UserPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/UserPreferences.java
@@ -25,6 +25,9 @@ public interface UserPreferences {
 	/** @return whether the time elapsed should be shown in Discord */
 	boolean showsElapsedTime();
 	
+	/** @return whether the programming language's icon should be shown in Discord */
+	boolean showsLanguageIcon();
+	
 	/** @return whether the name of the current project should be shown in Discord */
 	boolean resetsElapsedTimeOnStartup();
 	


### PR DESCRIPTION
See [related US](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/us/33).

Displays an image in Discord corresponding to the language of the active file.