### PR TITLE
Automate deployment

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -11,7 +11,9 @@
     </parent>
     
 	<modules>
-        <module>fr.kazejiyu.discord.rpc.integration</module>
         <module>com.github.psnrigner.discord-rpc-java</module>
+        <module>fr.kazejiyu.discord.rpc.integration</module>
+        <module>fr.kazejiyu.discord.rpc.integration.adapters</module>
+        <module>fr.kazejiyu.discord.rpc.integration.ui.preferences</module>
 	</modules>
 </project>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/.project
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.discord.rpc.integration.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/build.properties
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="fr.kazejiyu.discord.rpc.integration.feature"
+      label="Discord Rich Presence"
+      version="1.0.0.qualifier"
+      provider-name="Emmanuel CHEBBI">
+
+   <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
+      Integrates Discord Rich Presence within Eclipse IDE.
+
+Show the project you are working on and the name of the active file in Discord.
+   </description>
+
+   <license url="https://www.eclipse.org/legal/epl-2.0/">
+      Eclipse Public License - v 2.0
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS
+ECLIPSE
+PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION
+OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
+1. DEFINITIONS
+&quot;Contribution&quot; means:
+a) in the case of the initial Contributor, the initial content
+Distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate
+from
+and are Distributed by that particular Contributor. A Contribution
+&quot;originates&quot; from a Contributor if it was added to the Program
+by
+such Contributor itself or anyone acting on such Contributor&apos;s
+behalf.
+Contributions do not include changes or additions to the Program
+that
+are not Modified Works.
+&quot;Contributor&quot; means any person or entity that Distributes the
+Program.
+&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor
+which
+are necessarily infringed by the use or sale of its Contribution
+alone
+or when combined with the Program.
+&quot;Program&quot; means the Contributions Distributed in accordance with
+this
+Agreement.
+&quot;Recipient&quot; means anyone who receives the Program under this
+Agreement
+or any Secondary License (as applicable), including Contributors.
+&quot;Derivative Works&quot; shall mean any work, whether in Source Code
+or other
+form, that is based on (or derived from) the Program and for
+which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+&quot;Modified Works&quot; shall mean any work in Source Code or other
+form that
+results from an addition to, deletion from, or modification of
+the
+contents of the Program, including, for purposes of clarity any
+new file
+in Source Code form that contains any contents of the Program.
+Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program
+solely
+in each case in order to link to, bind by name, or subclass the
+Program
+or Modified Works thereof.
+&quot;Distribute&quot; means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+&quot;Source Code&quot; means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+&quot;Secondary License&quot; means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including
+any
+exceptions or additional permissions as identified by the initial
+Contributor.
+2. GRANT OF RIGHTS
+a) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free copyright
+license to reproduce, prepare Derivative Works of, publicly display,
+publicly perform, Distribute and sublicense the Contribution
+of such
+Contributor, if any, and such Derivative Works.
+b) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free patent
+license under Licensed Patents to make, use, sell, offer to sell,
+import and otherwise transfer the Contribution of such Contributor,
+if any, in Source Code or other form. This patent license shall
+apply to the combination of the Contribution and the Program
+if, at
+the time the Contribution is added by the Contributor, such addition
+of the Contribution causes such combination to be covered by
+the
+Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per
+se is
+licensed hereunder.
+c) Recipient understands that although each Contributor grants
+the
+licenses to its Contributions set forth herein, no assurances
+are
+provided by any Contributor that the Program does not infringe
+the
+patent or other intellectual property rights of any other entity.
+Each Contributor disclaims any liability to Recipient for claims
+brought by any other entity based on infringement of intellectual
+property rights or otherwise. As a condition to exercising the
+rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual
+property rights needed, if any. For example, if a third party
+patent license is required to allow Recipient to Distribute the
+Program, it is Recipient&apos;s responsibility to acquire that license
+before distributing the Program.
+d) Each Contributor represents that to its knowledge it has
+sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.
+e) Notwithstanding the terms of any Secondary License, no
+Contributor makes additional grants to any Recipient (other than
+those set forth in this Agreement) as a result of such Recipient&apos;s
+receipt of the Program under the terms of a Secondary License
+(if permitted under the terms of Section 3).
+3. REQUIREMENTS
+3.1 If a Contributor Distributes the Program in any form, then:
+a) the Program must also be made available as Source Code, in
+accordance with section 3.2, and the Contributor must accompany
+the Program with a statement that the Source Code for the Program
+is available under this Agreement, and informs Recipients how
+to
+obtain it in a reasonable manner on or through a medium customarily
+used for software exchange; and
+b) the Contributor may Distribute the Program under a license
+different than this Agreement, provided that such license:
+i) effectively disclaims on behalf of all other Contributors
+all
+warranties and conditions, express and implied, including
+warranties or conditions of title and non-infringement, and
+implied warranties or conditions of merchantability and fitness
+for a particular purpose;
+ii) effectively excludes on behalf of all other Contributors
+all
+liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;
+iii) does not attempt to limit or alter the recipients&apos; rights
+in the Source Code under section 3.2; and
+iv) requires any subsequent distribution of the Program by any
+party to be under a license that satisfies the requirements
+of this section 3.
+3.2 When the Program is Distributed as Source Code:
+a) it must be made available under this Agreement, or if the
+Program (i) is combined with other material in a separate file
+or
+files made available under a Secondary License, and (ii) the
+initial
+Contributor attached to the Source Code the notice described
+in
+Exhibit A of this Agreement, then the Program may be made available
+under the terms of such Secondary Licenses, and
+b) a copy of this Agreement must be included with each copy of
+the Program.
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability (&quot;notices&quot;) contained within the Program from any
+copy of
+the Program which they Distribute, provided that Contributors
+may add
+their own appropriate notices.
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While
+this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor
+includes
+the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify
+every
+other Contributor (&quot;Indemnified Contributor&quot;) against any losses,
+damages and costs (collectively &quot;Losses&quot;) arising from claims,
+lawsuits
+and other legal actions brought by a third party against the
+Indemnified
+Contributor to the extent caused by the acts or omissions of
+such
+Commercial Contributor in connection with its distribution of
+the Program
+in a commercial product offering. The obligations in this section
+do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor
+in
+writing of such claim, and b) allow the Commercial Contributor
+to control,
+and cooperate with the Commercial Contributor in, the defense
+and any
+related settlement negotiations. The Indemnified Contributor
+may
+participate in any such claim at its own expense.
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor&apos;s responsibility
+alone. Under this section, the Commercial Contributor would have
+to
+defend claims against the other Contributors related to those
+performance
+claims and warranties, and if a court requires any other Contributor
+to
+pay any damages as a result, the Commercial Contributor must
+pay
+those damages.
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &quot;AS
+IS&quot;
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS
+OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining
+the
+appropriateness of using and distributing the Program and assumes
+all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM
+OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF
+THE
+POSSIBILITY OF SUCH DAMAGES.
+7. GENERAL
+If any provision of this Agreement is invalid or unenforceable
+under
+applicable law, it shall not affect the validity or enforceability
+of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed
+to the
+minimum extent necessary to make such provision valid and enforceable.
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging
+that the
+Program itself (excluding combinations of the Program with other
+software
+or hardware) infringes such Recipient&apos;s patent(s), then such
+Recipient&apos;s
+rights granted under Section 2(b) shall terminate as of the date
+such
+litigation is filed.
+All Recipient&apos;s rights under this Agreement shall terminate if
+it
+fails to comply with any of the material terms or conditions
+of this
+Agreement and does not cure such failure in a reasonable period
+of
+time after becoming aware of such noncompliance. If all Recipient&apos;s
+rights under this Agreement terminate, Recipient agrees to cease
+use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient&apos;s obligations under this Agreement and any
+licenses
+granted by Recipient relating to the Program shall continue and
+survive.
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted
+and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions)
+of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may
+assign the
+responsibility to serve as the Agreement Steward to a suitable
+separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always
+be
+Distributed subject to the version of the Agreement under which
+it was
+received. In addition, after a new version of the Agreement is
+published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of
+any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly
+granted
+under this Agreement are reserved. Nothing in this Agreement
+is intended
+to be enforceable by any entity that is not a Contributor or
+Recipient.
+No third-party beneficiary rights are created under this Agreement.
+Exhibit A - Form of Secondary Licenses Notice
+&quot;This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability
+set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}.&quot;
+Simply including a copy of this Agreement, including this Exhibit
+A
+is not sufficient to license the Source Code under Secondary
+Licenses.
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as
+a LICENSE
+file in a relevant directory) where a recipient would be likely
+to
+look for such a notice.
+You may add additional accurate notices of copyright ownership.
+   </license>
+
+   <requires>
+      <import plugin="org.eclipse.ui.workbench"/>
+      <import plugin="org.eclipse.ui.ide" version="3.13.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.ui"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="com.github.psnrigner.discord-rpc-java" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui.editors" version="3.11.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources" version="3.12.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="fr.kazejiyu.discord.rpc.integration.adapters"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.github.psnrigner.discord-rpc-java"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="fr.kazejiyu.discord.rpc.integration"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/.project
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.discord.rpc.integration.ui.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/build.properties
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="fr.kazejiyu.discord.rpc.integration.ui.feature"
+      label="Discord Rich Presence UI"
+      version="1.0.0.qualifier">
+
+   <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
+      Adds pages to Eclipse Preferences to customize the information shown in Discord.
+   </description>
+
+   <license url="https://www.eclipse.org/legal/epl-2.0/">
+      Eclipse Public License - v 2.0
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS
+ECLIPSE
+PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION
+OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
+1. DEFINITIONS
+&quot;Contribution&quot; means:
+a) in the case of the initial Contributor, the initial content
+Distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate
+from
+and are Distributed by that particular Contributor. A Contribution
+&quot;originates&quot; from a Contributor if it was added to the Program
+by
+such Contributor itself or anyone acting on such Contributor&apos;s
+behalf.
+Contributions do not include changes or additions to the Program
+that
+are not Modified Works.
+&quot;Contributor&quot; means any person or entity that Distributes the
+Program.
+&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor
+which
+are necessarily infringed by the use or sale of its Contribution
+alone
+or when combined with the Program.
+&quot;Program&quot; means the Contributions Distributed in accordance with
+this
+Agreement.
+&quot;Recipient&quot; means anyone who receives the Program under this
+Agreement
+or any Secondary License (as applicable), including Contributors.
+&quot;Derivative Works&quot; shall mean any work, whether in Source Code
+or other
+form, that is based on (or derived from) the Program and for
+which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+&quot;Modified Works&quot; shall mean any work in Source Code or other
+form that
+results from an addition to, deletion from, or modification of
+the
+contents of the Program, including, for purposes of clarity any
+new file
+in Source Code form that contains any contents of the Program.
+Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program
+solely
+in each case in order to link to, bind by name, or subclass the
+Program
+or Modified Works thereof.
+&quot;Distribute&quot; means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+&quot;Source Code&quot; means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+&quot;Secondary License&quot; means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including
+any
+exceptions or additional permissions as identified by the initial
+Contributor.
+2. GRANT OF RIGHTS
+a) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free copyright
+license to reproduce, prepare Derivative Works of, publicly display,
+publicly perform, Distribute and sublicense the Contribution
+of such
+Contributor, if any, and such Derivative Works.
+b) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free patent
+license under Licensed Patents to make, use, sell, offer to sell,
+import and otherwise transfer the Contribution of such Contributor,
+if any, in Source Code or other form. This patent license shall
+apply to the combination of the Contribution and the Program
+if, at
+the time the Contribution is added by the Contributor, such addition
+of the Contribution causes such combination to be covered by
+the
+Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per
+se is
+licensed hereunder.
+c) Recipient understands that although each Contributor grants
+the
+licenses to its Contributions set forth herein, no assurances
+are
+provided by any Contributor that the Program does not infringe
+the
+patent or other intellectual property rights of any other entity.
+Each Contributor disclaims any liability to Recipient for claims
+brought by any other entity based on infringement of intellectual
+property rights or otherwise. As a condition to exercising the
+rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual
+property rights needed, if any. For example, if a third party
+patent license is required to allow Recipient to Distribute the
+Program, it is Recipient&apos;s responsibility to acquire that license
+before distributing the Program.
+d) Each Contributor represents that to its knowledge it has
+sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.
+e) Notwithstanding the terms of any Secondary License, no
+Contributor makes additional grants to any Recipient (other than
+those set forth in this Agreement) as a result of such Recipient&apos;s
+receipt of the Program under the terms of a Secondary License
+(if permitted under the terms of Section 3).
+3. REQUIREMENTS
+3.1 If a Contributor Distributes the Program in any form, then:
+a) the Program must also be made available as Source Code, in
+accordance with section 3.2, and the Contributor must accompany
+the Program with a statement that the Source Code for the Program
+is available under this Agreement, and informs Recipients how
+to
+obtain it in a reasonable manner on or through a medium customarily
+used for software exchange; and
+b) the Contributor may Distribute the Program under a license
+different than this Agreement, provided that such license:
+i) effectively disclaims on behalf of all other Contributors
+all
+warranties and conditions, express and implied, including
+warranties or conditions of title and non-infringement, and
+implied warranties or conditions of merchantability and fitness
+for a particular purpose;
+ii) effectively excludes on behalf of all other Contributors
+all
+liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;
+iii) does not attempt to limit or alter the recipients&apos; rights
+in the Source Code under section 3.2; and
+iv) requires any subsequent distribution of the Program by any
+party to be under a license that satisfies the requirements
+of this section 3.
+3.2 When the Program is Distributed as Source Code:
+a) it must be made available under this Agreement, or if the
+Program (i) is combined with other material in a separate file
+or
+files made available under a Secondary License, and (ii) the
+initial
+Contributor attached to the Source Code the notice described
+in
+Exhibit A of this Agreement, then the Program may be made available
+under the terms of such Secondary Licenses, and
+b) a copy of this Agreement must be included with each copy of
+the Program.
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability (&quot;notices&quot;) contained within the Program from any
+copy of
+the Program which they Distribute, provided that Contributors
+may add
+their own appropriate notices.
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While
+this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor
+includes
+the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify
+every
+other Contributor (&quot;Indemnified Contributor&quot;) against any losses,
+damages and costs (collectively &quot;Losses&quot;) arising from claims,
+lawsuits
+and other legal actions brought by a third party against the
+Indemnified
+Contributor to the extent caused by the acts or omissions of
+such
+Commercial Contributor in connection with its distribution of
+the Program
+in a commercial product offering. The obligations in this section
+do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor
+in
+writing of such claim, and b) allow the Commercial Contributor
+to control,
+and cooperate with the Commercial Contributor in, the defense
+and any
+related settlement negotiations. The Indemnified Contributor
+may
+participate in any such claim at its own expense.
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor&apos;s responsibility
+alone. Under this section, the Commercial Contributor would have
+to
+defend claims against the other Contributors related to those
+performance
+claims and warranties, and if a court requires any other Contributor
+to
+pay any damages as a result, the Commercial Contributor must
+pay
+those damages.
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &quot;AS
+IS&quot;
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS
+OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining
+the
+appropriateness of using and distributing the Program and assumes
+all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM
+OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF
+THE
+POSSIBILITY OF SUCH DAMAGES.
+7. GENERAL
+If any provision of this Agreement is invalid or unenforceable
+under
+applicable law, it shall not affect the validity or enforceability
+of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed
+to the
+minimum extent necessary to make such provision valid and enforceable.
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging
+that the
+Program itself (excluding combinations of the Program with other
+software
+or hardware) infringes such Recipient&apos;s patent(s), then such
+Recipient&apos;s
+rights granted under Section 2(b) shall terminate as of the date
+such
+litigation is filed.
+All Recipient&apos;s rights under this Agreement shall terminate if
+it
+fails to comply with any of the material terms or conditions
+of this
+Agreement and does not cure such failure in a reasonable period
+of
+time after becoming aware of such noncompliance. If all Recipient&apos;s
+rights under this Agreement terminate, Recipient agrees to cease
+use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient&apos;s obligations under this Agreement and any
+licenses
+granted by Recipient relating to the Program shall continue and
+survive.
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted
+and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions)
+of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may
+assign the
+responsibility to serve as the Agreement Steward to a suitable
+separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always
+be
+Distributed subject to the version of the Agreement under which
+it was
+received. In addition, after a new version of the Agreement is
+published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of
+any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly
+granted
+under this Agreement are reserved. Nothing in this Agreement
+is intended
+to be enforceable by any entity that is not a Contributor or
+Recipient.
+No third-party beneficiary rights are created under this Agreement.
+Exhibit A - Form of Secondary Licenses Notice
+&quot;This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability
+set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}.&quot;
+Simply including a copy of this Agreement, including this Exhibit
+A
+is not sufficient to license the Source Code under Secondary
+Licenses.
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as
+a LICENSE
+file in a relevant directory) where a recipient would be likely
+to
+look for such a notice.
+You may add additional accurate notices of copyright ownership.
+   </license>
+
+   <requires>
+      <import plugin="org.eclipse.ui"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="fr.kazejiyu.discord.rpc.integration" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources"/>
+   </requires>
+
+   <plugin
+         id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -11,5 +11,7 @@
     </parent>
     
 	<modules>
+        <module>fr.kazejiyu.discord.rpc.integration.feature</module>
+        <module>fr.kazejiyu.discord.rpc.integration.ui.feature</module>
 	</modules>
 </project>

--- a/releng/fr.kazejiyu.discord.rpc.integration.configuration/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.configuration/pom.xml
@@ -22,6 +22,12 @@
 				<version>${tycho.version}</version>
 				<extensions>true</extensions>
 			</plugin>
+            <!-- Ease version change -->
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-versions-plugin</artifactId>
+                <version>${tycho.version}</version>
+            </plugin>
 			<!-- Specify a target platform -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/.project
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.discord.rpc.integration.p2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.UpdateSiteBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.UpdateSiteNature</nature>
+	</natures>
+</projectDescription>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/bintray.ant
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/bintray.ant
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="Handle p2 composite metadata from Bintray" basedir=".">
+
+	<!--
+	These must be set from outside
+	<property name="bintray.user" value="" />
+	<property name="bintray.apikey" value="" />
+	<property name="bintray.repo" value="" />
+	<property name="bintray.package" value="" />
+	<property name="bintray.releases.path" value="" />
+	<property name="bintray.composite.path" value="" />
+	<property name="bintray.zip.path" value="" />
+	-->
+
+	<property name="bintray.url" value="https://dl.bintray.com/${bintray.owner}/${bintray.repo}" />
+	<property name="bintray.package.version" value="${unqualifiedVersion}.${buildQualifier}" />
+	<property name="bintray.releases.target.path" value="${bintray.releases.path}/${bintray.package.version}" />
+
+	<property name="main.composite.url" value="${bintray.url}/${bintray.composite.path}" />
+	<property name="target" value="target" />
+	<property name="composite.repository.directory" value="composite-child" />
+	<property name="main.composite.repository.directory" value="composite-main" />
+
+	<property name="compositeArtifacts" value="compositeArtifacts.xml" />
+	<property name="compositeContent" value="compositeContent.xml" />
+
+	<property name="local.p2.repository" value="target/repository" />
+
+	<target name="getMajorMinorVersion">
+		<script language="javascript">
+			<![CDATA[
+	                // getting the value
+	                buildnumber = project.getProperty("unqualifiedVersion");
+	                index = buildnumber.lastIndexOf(".");
+	                counter = buildnumber.substring(0, index);
+	    			project.setProperty("majorMinorVersion",counter);
+	            ]]>
+		</script>
+	</target>
+
+	<!-- Take from the remote URL the possible existing metadata -->
+	<target name="get-composite-metadata" depends="getMajorMinorVersion" >
+		<get-metadata url="${main.composite.url}" dest="${target}/${main.composite.repository.directory}" />
+		<get-metadata url="${main.composite.url}/${majorMinorVersion}" dest="${target}/${composite.repository.directory}" />
+		<antcall target="preprocess-metadata" />
+	</target>
+
+	<macrodef name="get-metadata" description="Retrieve the p2 composite metadata">
+		<attribute name="url" />
+		<attribute name="dest" />
+		<sequential>
+			<echo message="Creating directory @{dest}..." />
+			<mkdir dir="@{dest}" />
+			<get-file file="${compositeArtifacts}" url="@{url}" dest="@{dest}" />
+			<get-file file="${compositeContent}" url="@{url}" dest="@{dest}" />
+		</sequential>
+	</macrodef>
+
+	<macrodef name="get-file" description="Use Ant Get task the file">
+		<attribute name="file" />
+		<attribute name="url" />
+		<attribute name="dest" />
+		<sequential>
+			<!-- If the remote file does not exist then fail gracefully -->
+			<echo message="Getting @{file} from @{url} into @{dest}..." />
+			<get dest="@{dest}" ignoreerrors="true">
+				<url url="@{url}/@{file}" />
+			</get>
+		</sequential>
+	</macrodef>
+
+	<!-- p2.atomic.composite.loading must be set to false otherwise we won't be able
+		to add a child to the composite repository without having all the children available -->
+	<target name="preprocess-metadata" description="Preprocess p2 composite metadata">
+		<replaceregexp byline="true">
+			<regexp pattern="property name='p2.atomic.composite.loading' value='true'" />
+			<substitution expression="property name='p2.atomic.composite.loading' value='false'" />
+			<fileset dir="${target}">
+				<include name="${composite.repository.directory}/*.xml" />
+				<include name="${main.composite.repository.directory}/*.xml" />
+			</fileset>
+		</replaceregexp>
+	</target>
+
+	<!-- p2.atomic.composite.loading must be set to true
+		see https://bugs.eclipse.org/bugs/show_bug.cgi?id=356561 -->
+	<target name="postprocess-metadata" description="Preprocess p2 composite metadata">
+		<replaceregexp byline="true">
+			<regexp pattern="property name='p2.atomic.composite.loading' value='false'" />
+			<substitution expression="property name='p2.atomic.composite.loading' value='true'" />
+			<fileset dir="${target}">
+				<include name="${composite.repository.directory}/*.xml" />
+				<include name="${main.composite.repository.directory}/*.xml" />
+			</fileset>
+		</replaceregexp>
+	</target>
+
+	<target name="push-to-bintray" >
+		<antcall target="postprocess-metadata" />
+		<antcall target="push-p2-repo-to-bintray" />
+		<antcall target="push-p2-repo-zipped-to-bintray" />
+		<antcall target="push-composite-to-bintray" />
+		<antcall target="push-main-composite-to-bintray" />
+	</target>
+
+	<target name="push-p2-repo-to-bintray">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${local.p2.repository}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${local.p2.repository}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.releases.target.path}/*;bt_package=${bintray.package};bt_version=${bintray.package.version};publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-p2-repo-zipped-to-bintray">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}" includes="*.zip" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.zip.path}/*;bt_package=${bintray.package};bt_version=${bintray.package.version};publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-composite-to-bintray" depends="getMajorMinorVersion" >
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}/${composite.repository.directory}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/${composite.repository.directory}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.composite.path}/${majorMinorVersion}/*;publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+	<target name="push-main-composite-to-bintray" >
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+			<arg value="-XPUT" />
+			<targetfile />
+
+			<fileset dir="${target}/${main.composite.repository.directory}" />
+
+			<compositemapper>
+				<mergemapper to="-T" />
+				<globmapper from="*" to="${target}/${main.composite.repository.directory}/*" />
+				<mergemapper to="-u${bintray.user}:${bintray.apikey}" />
+				<globmapper from="*" to="https://api.bintray.com/content/${bintray.owner}/${bintray.repo}/${bintray.composite.path}/*;publish=1" />
+			</compositemapper>
+		</apply>
+	</target>
+
+</project>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/bintray.ant
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/bintray.ant
@@ -13,7 +13,14 @@
 	-->
 
 	<property name="bintray.url" value="https://dl.bintray.com/${bintray.owner}/${bintray.repo}" />
-	<property name="bintray.package.version" value="${unqualifiedVersion}.${buildQualifier}" />
+	<condition property="bintray.package.version" value="${unqualifiedVersion}" else="${unqualifiedVersion}.${buildQualifier}">
+		<or>
+			<not>
+				<isset property="buildQualifier"/>
+			</not>
+			<equals arg1="" arg2="${buildQualifier}"/>
+		</or>
+	</condition>
 	<property name="bintray.releases.target.path" value="${bintray.releases.path}/${bintray.package.version}" />
 
 	<property name="main.composite.url" value="${bintray.url}/${bintray.composite.path}" />
@@ -120,7 +127,7 @@
 	</target>
 
 	<target name="push-p2-repo-zipped-to-bintray">
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 
@@ -136,7 +143,7 @@
 	</target>
 
 	<target name="push-composite-to-bintray" depends="getMajorMinorVersion" >
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 
@@ -152,7 +159,7 @@
 	</target>
 
 	<target name="push-main-composite-to-bintray" >
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.0.0.qualifier.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.0.0.qualifier">
+      <category name="fr.kazejiyu.discord.rpc.integration"/>
+   </feature>
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.0.0.qualifier.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.0.0.qualifier">
+      <category name="fr.kazejiyu.discord.rpc.integration"/>
+   </feature>
+   <category-def name="fr.kazejiyu.discord.rpc.integration" label="Discord Rich Presence Integration">
+      <description>
+         Plug-ins integrating Discord Rich Presence within Eclipse IDE.
+      </description>
+   </category-def>
+</site>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/packaging-p2composite.ant
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/packaging-p2composite.ant
@@ -27,7 +27,14 @@
 										should be "../../releases/"
 	-->
 	<target name="compute.child.repository.data" depends="getMajorMinorVersion">
-		<property name="full.version" value="${unqualifiedVersion}.${buildQualifier}" />
+		<condition property="full.version" value="${unqualifiedVersion}" else="${unqualifiedVersion}.${buildQualifier}">
+			<or>
+				<not>
+					<isset property="buildQualifier"/>
+				</not>
+				<equals arg1="" arg2="${buildQualifier}"/>
+			</or>
+		</condition>
 
 		<property name="site.composite.name" value="${site.label} ${majorMinorVersion}" />
 		<property name="main.site.composite.name" value="${site.label} All Versions" />

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/packaging-p2composite.ant
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/packaging-p2composite.ant
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<project name="project">
+
+	<target name="getMajorMinorVersion">
+		<script language="javascript">
+			<![CDATA[
+	                // getting the value
+	                buildnumber = project.getProperty("unqualifiedVersion");
+	                index = buildnumber.lastIndexOf(".");
+	                counter = buildnumber.substring(0, index);
+	    			project.setProperty("majorMinorVersion",counter);
+	            ]]>
+		</script>
+	</target>
+
+	<target name="test_getMajorMinor" depends="getMajorMinorVersion">
+		<echo message="majorMinorVersion: ${majorMinorVersion}" />
+	</target>
+
+	<!--
+		site.label						The name/title/label of the created composite site
+		unqualifiedVersion 				The version without any qualifier replacement
+		buildQualifier					The build qualifier
+		child.repository.path.prefix	The path prefix to access the actual p2 repo from the
+										child repo, e.g., if child repo is in /updates/1.0 and
+										the p2 repo is in /releases/1.0.0.something then this property
+										should be "../../releases/"
+	-->
+	<target name="compute.child.repository.data" depends="getMajorMinorVersion">
+		<property name="full.version" value="${unqualifiedVersion}.${buildQualifier}" />
+
+		<property name="site.composite.name" value="${site.label} ${majorMinorVersion}" />
+		<property name="main.site.composite.name" value="${site.label} All Versions" />
+
+		<!-- composite.base.dir	The base directory for the local composite metadata,
+			e.g., from Maven, ${project.build.directory}
+		-->
+		<property name="composite.base.dir" value="target"/>
+
+		<property name="main.composite.repository.directory" location="${composite.base.dir}/composite-main" />
+		<property name="composite.repository.directory" location="${composite.base.dir}/composite-child" />
+
+		<property name="child.repository" value="${child.repository.path.prefix}${full.version}" />
+	</target>
+
+	<target name="p2.composite.add" depends="compute.child.repository.data">
+		<add.composite.repository.internal composite.repository.location="${main.composite.repository.directory}" composite.repository.name="${main.site.composite.name}" composite.repository.child="${majorMinorVersion}" />
+		<add.composite.repository.internal composite.repository.location="${composite.repository.directory}" composite.repository.name="${site.composite.name}" composite.repository.child="${child.repository}" />
+	</target>
+
+	<!-- = = = = = = = = = = = = = = = = =
+          macrodef: add.composite.repository.internal          
+         = = = = = = = = = = = = = = = = = -->
+	<macrodef name="add.composite.repository.internal">
+		<attribute name="composite.repository.location" />
+		<attribute name="composite.repository.name" />
+		<attribute name="composite.repository.child" />
+		<sequential>
+
+			<echo message=" " />
+			<echo message="Composite repository       : @{composite.repository.location}" />
+			<echo message="Composite name             : @{composite.repository.name}" />
+			<echo message="Adding child repository    : @{composite.repository.child}" />
+
+			<p2.composite.repository>
+				<repository compressed="false" location="@{composite.repository.location}" name="@{composite.repository.name}" />
+				<add>
+					<repository location="@{composite.repository.child}" />
+				</add>
+			</p2.composite.repository>
+
+			<echo file="@{composite.repository.location}/p2.index">version=1
+metadata.repository.factory.order=compositeContent.xml,\!
+artifact.repository.factory.order=compositeArtifacts.xml,\!
+</echo>
+
+		</sequential>
+	</macrodef>
+
+
+</project>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
+		<artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+</project>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -12,5 +12,127 @@
 
 	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>
 	<packaging>eclipse-repository</packaging>
+    
+    
+	<properties>
+		<bintray.repo>eclipse-discord-integration</bintray.repo>
+		<!-- The name of Bintray repository's package for releases -->
+		<bintray.package>releases</bintray.package>
+		<!-- The label for the Composite sites -->
+		<site.label>Discord Rich Presence for Eclipse IDE</site.label>
+
+		<bintray.owner>${bintray.user}</bintray.owner>
+
+		<!-- Default values for remote directories -->
+		<bintray.releases.path>releases</bintray.releases.path>
+		<bintray.composite.path>updates</bintray.composite.path>
+		<bintray.zip.path>zipped</bintray.zip.path>
+		<!-- note that the following must be consistent with the path schema
+			used to publish child composite repositories and actual released p2 repositories -->
+		<child.repository.path.prefix>../../releases/</child.repository.path.prefix>
+	</properties>
+    
+    <profiles>
+		<profile>
+			<!-- Activate this profile to perform the release to Bintray -->
+			<id>release-composite</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.7</version>
+						<executions>
+							<execution>
+								<!-- Retrieve possibly existing remote composite metadata -->
+								<id>update-local-repository</id>
+								<phase>prepare-package</phase>
+								<configuration>
+									<target>
+										<ant antfile="${basedir}/bintray.ant" target="get-composite-metadata">
+										</ant>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+							
+							<execution>
+								<!-- Deploy p2 repository, p2 composite updated metadata and zipped p2 repository -->
+								<id>deploy-repository</id>
+								<phase>verify</phase>
+								<configuration>
+									<target>
+										<ant antfile="${basedir}/bintray.ant" target="push-to-bintray">
+										</ant>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-eclipserun-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<!-- Update p2 composite metadata or create it -->
+							<!-- IMPORTANT: DO NOT split the arg line -->
+							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DbuildQualifier=${buildQualifier} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
+							<repositories>
+								<repository>
+									<id>mars</id>
+									<layout>p2</layout>
+									<url>http://download.eclipse.org/releases/mars</url>
+								</repository>
+							</repositories>
+							<dependencies>
+								<dependency>
+									<artifactId>org.eclipse.ant.core</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.apache.ant</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.repository.tools</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.core.feature</artifactId>
+									<type>eclipse-feature</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.p2.extras.feature</artifactId>
+									<type>eclipse-feature</type>
+								</dependency>
+								<dependency>
+									<artifactId>org.eclipse.equinox.ds</artifactId>
+									<type>eclipse-plugin</type>
+								</dependency>
+							</dependencies>
+						</configuration>
+						<executions>
+							<execution>
+								<id>add-p2-composite-repository</id>
+								<phase>package</phase>
+								<goals>
+									<goal>eclipse-run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -34,7 +34,7 @@
     
     <profiles>
 		<profile>
-			<!-- Activate this profile to perform the release to Bintray -->
+			<!-- Activate this profile to release a legacy version (x.y.z) to Bintray -->
 			<id>release-composite</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/removeFromBintray.sh
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/removeFromBintray.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# remove p2 metadata artifacts from bintray remote path
+#Sample Usage: removeFromBintray.sh apikey remotePath
+API=https://api.bintray.com
+
+BINTRAY_API_KEY=$1
+PATH_TO_REPOSITORY=$2
+
+BINTRAY_USER=lorenzobettini
+BINTRAY_REPO=p2-composite-example
+
+function main() {
+remove_p2_metadata
+}
+
+function remove_p2_metadata() {
+echo "${BINTRAY_USER}"
+echo "${BINTRAY_API_KEY}"
+echo "${BINTRAY_REPO}"
+echo "${PCK_NAME}"
+echo "${PCK_VERSION}"
+echo "${PATH_TO_REPOSITORY}"
+
+
+echo "Removing metadata content.jar..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/content.jar"
+echo ""
+echo "Removing metadata artifacts.jar..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/artifacts.jar"
+echo ""
+echo "Removing metadata compositeContent.xml..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/compositeContent.xml"
+echo ""
+echo "Removing metadata compositeArtifacts.xml..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/compositeArtifacts.xml"
+echo ""
+echo "Removing metadata p2.index..."
+curl -X DELETE -u${BINTRAY_USER}:${BINTRAY_API_KEY} "https://api.bintray.com/content/${BINTRAY_USER}/${BINTRAY_REPO}/${PATH_TO_REPOSITORY}/p2.index"
+echo ""
+
+}
+
+
+
+main "$@"

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,5 +12,6 @@
     
 	<modules>
         <module>fr.kazejiyu.discord.rpc.integration.target</module>
+        <module>fr.kazejiyu.discord.rpc.integration.p2</module>
 	</modules>
 </project>


### PR DESCRIPTION
See [related US](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/us/5).

Adds two Maven commands:

- `mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=1.0.0` to change plug-in's version,
- `mvn clean verify -Prelease-composite` to release the version on Bintray.

A future PR will setup Travis CI to release a new version each time a Git tag is created, and to release a nightly for each successful build.