### PR TITLE
[FIX #23] Show Discord Preferences page in project Properties

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/plugin.xml
@@ -21,11 +21,11 @@
             class="fr.kazejiyu.discord.rpc.integration.ui.preferences.properties.ProjectPropertiesPage"
             id="fr.kazejiyu.discord.rpc.integration.ui.preferences.properties.projectPropertiesPage"
             name="Discord Rich Presence"
-            nameFilter="*">
+            selectionFilter="single">
          <enabledWhen>
-            <instanceof
-                  value="org.eclipse.core.resources.IProject">
-            </instanceof>
+            <adapt
+                  type="org.eclipse.core.resources.IProject">
+            </adapt>
          </enabledWhen>
       </page>
    </extension>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
@@ -15,14 +15,15 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_STARTUP;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
-import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.USE_PROJECT_SETTINGS;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.swt.SWT;
@@ -65,10 +66,9 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 	
 	@Override
 	protected Control createContents(Composite parent) {
-		if (!(getElement() instanceof IProject))
+		if (! resolveCurrentProject())
 			return new Composite(parent, SWT.NONE);
 		
-		project = (IProject) getElement();
 		IScopeContext context = new ProjectScope(project);
 		preferences = context.getNode("fr.kazejiyu.discord.rpc.integration");
 		
@@ -101,6 +101,22 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 		} catch (CoreException e) { /* Should never happen */ }
 		
 		return composite;
+	}
+	
+	/**
+	 * Sets {@link #project} to the value of the current project.
+	 * 
+	 * @return {@code true} if the current project has been resolved successfully,
+	 * 		   {@code false} otherwise.
+	 */
+	private boolean resolveCurrentProject() {
+		final IAdaptable adaptable = getElement();
+		
+		if (adaptable == null)
+			return false;
+		
+		project = adaptable.getAdapter(IProject.class);
+		return project != null;
 	}
 
 	private void setMissingPropertiesToDefault(IResource resource) throws CoreException {


### PR DESCRIPTION
Replacing the `instanceof` tag by `adapt` seems to fix the issue.

`adapt` makes possible to show the Discord Preferences page within the Properties dialog of any object adaptable to `IProject`, whereas `instanceof` works only for instances of `IProject`.