### PR TITLE
[FIX #29] Make the plug-in available from Eclipse Mars

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=tru
 Bundle-Version: 0.8.1
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: fr.kazejiyu.discord.rpc.integration,
- org.eclipse.ui.workbench,
- org.eclipse.ui.ide;bundle-version="3.13.1",
- org.eclipse.core.resources
+Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.1",
+ org.eclipse.ui.workbench;bundle-version="[3.107.0,4.0.0)",
+ org.eclipse.ui.ide;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"
 Bundle-Vendor: Emmanuel CHEBBI

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Integration Default Adapters
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
-Bundle-Version: 0.8.1
+Bundle-Version: 0.8.2
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.1",
+Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",
  org.eclipse.ui.workbench;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.11.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Integration Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
-Bundle-Version: 0.8.1
+Bundle-Version: 0.8.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
- fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.1",
+ fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",
  org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.ui.preferences

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: Discord Integration Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
 Bundle-Version: 0.8.1
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
- fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.0",
- org.eclipse.core.resources
+Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.1",
+ org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.ui.preferences
 Bundle-ActivationPolicy: lazy

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Discord Integration
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
-Bundle-Version: 0.8.1
+Bundle-Version: 0.8.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -4,12 +4,12 @@ Bundle-Name: Eclipse Discord Integration
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
 Bundle-Version: 0.8.1
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
- com.github.psnrigner.discord-rpc-java;bundle-version="1.0.0",
- org.eclipse.ui.editors;bundle-version="3.11.0",
- org.eclipse.ui.ide;bundle-version="3.13.1",
- org.eclipse.core.resources;bundle-version="3.12.0"
+Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ com.github.psnrigner.discord-rpc-java;bundle-version="1.0.5",
+ org.eclipse.ui.editors;bundle-version="[3.9.0,4.0.0)",
+ org.eclipse.ui.ide;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: fr.kazejiyu.discord.rpc.integration.core,
  fr.kazejiyu.discord.rpc.integration.extensions,

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
     </parent>
     
 	<modules>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.feature"
       label="Discord Rich Presence"
-      version="0.8.1"
+      version="0.8.2"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -351,7 +351,7 @@ You may add additional accurate notices of copyright ownership.
          id="fr.kazejiyu.discord.rpc.integration.adapters"
          download-size="0"
          install-size="0"
-         version="0.8.1"
+         version="0.8.2"
          unpack="false"/>
 
    <plugin
@@ -364,7 +364,7 @@ You may add additional accurate notices of copyright ownership.
          id="fr.kazejiyu.discord.rpc.integration"
          download-size="0"
          install-size="0"
-         version="0.8.1"
+         version="0.8.2"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -337,34 +337,34 @@ You may add additional accurate notices of copyright ownership.
    </url>
 
    <requires>
-      <import plugin="org.eclipse.ui.workbench"/>
-      <import plugin="org.eclipse.ui.ide" version="3.13.1" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.resources"/>
-      <import plugin="org.eclipse.ui"/>
-      <import plugin="org.eclipse.core.runtime"/>
-      <import plugin="com.github.psnrigner.discord-rpc-java" version="1.0.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.ui.editors" version="3.11.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.resources" version="3.12.0" match="greaterOrEqual"/>
+      <import plugin="fr.kazejiyu.discord.rpc.integration" version="0.8.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui.workbench" version="3.107.0" match="compatible"/>
+      <import plugin="org.eclipse.ui.ide" version="3.11.0" match="compatible"/>
+      <import plugin="org.eclipse.core.resources" version="3.10.0" match="compatible"/>
+      <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
+      <import plugin="org.eclipse.core.runtime" version="3.11.0" match="compatible"/>
+      <import plugin="com.github.psnrigner.discord-rpc-java" version="1.0.5" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.ui.editors" version="3.9.0" match="compatible"/>
    </requires>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration.adapters"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="0.8.1"
          unpack="false"/>
 
    <plugin
          id="com.github.psnrigner.discord-rpc-java"
          download-size="0"
          install-size="0"
-         version="0.0.0"/>
+         version="1.0.5"/>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="0.8.1"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.ui.feature"
       label="Discord Rich Presence UI"
-      version="0.8.1"
+      version="0.8.2"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -345,7 +345,7 @@ You may add additional accurate notices of copyright ownership.
          id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
          download-size="0"
          install-size="0"
-         version="0.8.1"
+         version="0.8.2"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -335,17 +335,17 @@ You may add additional accurate notices of copyright ownership.
    </url>
 
    <requires>
-      <import plugin="org.eclipse.ui"/>
-      <import plugin="org.eclipse.core.runtime"/>
-      <import plugin="fr.kazejiyu.discord.rpc.integration" version="0.8.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
+      <import plugin="org.eclipse.core.runtime" version="3.11.0" match="compatible"/>
+      <import plugin="fr.kazejiyu.discord.rpc.integration" version="0.8.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources" version="3.10.0" match="compatible"/>
    </requires>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="0.8.1"
          unpack="false"/>
 
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
     </parent>
     
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 	<packaging>pom</packaging>
     
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.configuration</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
         <relativePath>./releng/fr.kazejiyu.discord.rpc.integration.configuration</relativePath>
     </parent>
     

--- a/releng/fr.kazejiyu.discord.rpc.integration.configuration/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.configuration/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
     <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 	<artifactId>fr.kazejiyu.discord.rpc.integration.configuration</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -38,7 +38,7 @@
                         <artifact>
                             <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
                             <artifactId>fr.kazejiyu.discord.rpc.integration.target</artifactId>
-                            <version>0.8.1</version>
+                            <version>0.8.2</version>
                         </artifact>
                     </target>
 					<environments>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_0.8.1.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="0.8.1">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_0.8.2.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="0.8.2">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_0.8.1.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="0.8.1">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_0.8.2.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="0.8.2">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
    <category-def name="fr.kazejiyu.discord.rpc.integration" label="Discord Rich Presence Integration">

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -85,7 +85,7 @@
 						<configuration>
 							<!-- Update p2 composite metadata or create it -->
 							<!-- IMPORTANT: DO NOT split the arg line -->
-							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DbuildQualifier=${buildQualifier} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
+							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
 							<repositories>
 								<repository>
 									<id>mars</id>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-		<version>0.8.1</version>
+		<version>0.8.2</version>
 	</parent>
 
 	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>

--- a/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
     </parent>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
     </parent>
     
 	<modules>


### PR DESCRIPTION
The plugin-in can now be installed on Eclipse Mars and Neon.

This PR fixes issue #29.