### PR TITLE
Update the name of some plug-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Rich Presence for Eclipse IDE
 
-![Build Status](https://travis-ci.org/KazeJiyu/eclipse-discord-integration.svg?branch=master) [![Managed with TAIGA.io](https://img.shields.io/badge/managed%20with-TAIGA.io-brightgreen.svg)](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/)
+![Build Status](https://travis-ci.org/KazeJiyu/eclipse-discord-integration.svg?branch=master) [![Managed with TAIGA.io](https://img.shields.io/badge/managed%20with-TAIGA.io-brightgreen.svg)](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/) [![Bintray](https://img.shields.io/bintray/v/kazejiyu/eclipse-discord-integration/releases.svg)](https://bintray.com/kazejiyu/eclipse-discord-integration)
 
 ## Presentation
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently, there is no option to prevent this once the plug-in is started. Howev
 
 1. Open Eclipse Preferences (`Help` > `Preferences`)
 2. Open the _Startup and Shutdown_ page (`Window` > `Startup and Shutdown`)
-3. Uncheck _Eclipse Discord Integration_
+3. Uncheck _Discord Rich Presence for Eclipse IDE_
 4. Reboot Eclipse IDE
 
 From that time on, Discord won't be notified anymore by Eclipse IDE. In order to re-activate Rich Presence, follow the steps above and check _Eclipse Discord Integration_ again.

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Discord Integration Default Adapters
+Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
 Bundle-Version: 0.8.2
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Discord Integration Preferences
+Bundle-Name: Discord Rich Presence for Eclipse IDE — Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
 Bundle-Version: 0.8.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse Discord Integration
+Bundle-Name: Discord Rich Presence for Eclipse IDE
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
 Bundle-Version: 0.8.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator


### PR DESCRIPTION
Some plug-ins were still using the old 'Eclipse Discord Integration' name.

This PR:
 - rename them _Discord Rich Presence for Eclipse IDE_,
 - add a Bintray badge to README.