### PR TITLE
Choose project name

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultFileEditorInputRichPresence.java
@@ -90,7 +90,10 @@ public class DefaultFileEditorInputRichPresence implements EditorInputRichPresen
 		if (! preferences.showsProjectName())
 			return "";
 		
-		return "Working on " + ((project != null) ? project.getName() : "an unknown project");
+		String projectName = preferences.getProjectName().orElse((project != null) ? project.getName() 
+																				   : "an unknown project");
+		
+		return "Working on " + projectName;
 	}
 
 	private Language languageOf(UserPreferences preferences, IFile file) {

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/src/fr/kazejiyu/discord/rpc/integration/ui/preferences/properties/ProjectPropertiesPage.java
@@ -9,6 +9,7 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.ui.preferences.properties;
 
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_FILE;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_PROJECT;
@@ -36,6 +37,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchPropertyPage;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.osgi.service.prefs.BackingStoreException;
@@ -63,6 +65,9 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 	private Button resetOnStartup;
 	private Button resetOnProjectSelection;
 	private Button resetOnFileSelection;
+	
+	private Text projectName;
+	private Label projectNameLabel;
 	
 	@Override
 	protected Control createContents(Composite parent) {
@@ -132,11 +137,14 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			resource.setPersistentProperty(SHOW_ELAPSED_TIME.qualifiedName(), "true");
 		if (resource.getPersistentProperty(RESET_ELAPSED_TIME.qualifiedName()) == null)
 			resource.setPersistentProperty(RESET_ELAPSED_TIME.qualifiedName(), RESET_ELAPSED_TIME_ON_NEW_PROJECT.property());
+		if (resource.getPersistentProperty(PROJECT_NAME.qualifiedName()) == null)
+			resource.setPersistentProperty(PROJECT_NAME.qualifiedName(), "");
 	}
 	
 	@Override
 	public void performDefaults() {
 		super.performDefaults();
+		projectName.setText("");
 		showProjectName.setSelection(true);
 		showFileName.setSelection(true);
 		showElapsedTime.setSelection(true);
@@ -153,6 +161,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 	@Override
 	public boolean performOk() {
 		try {
+			project.setPersistentProperty(PROJECT_NAME.qualifiedName(), projectName.getText());
 			project.setPersistentProperty(USE_PROJECT_SETTINGS.qualifiedName(), useProjectSettings.getSelection() + "");
 			project.setPersistentProperty(SHOW_PROJECT_NAME.qualifiedName(), showProjectName.getSelection() + "");
 			project.setPersistentProperty(SHOW_FILE_NAME.qualifiedName(), showFileName.getSelection() + "");
@@ -166,6 +175,7 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 			if (resetOnFileSelection.getSelection())
 				project.setPersistentProperty(RESET_ELAPSED_TIME.qualifiedName(), RESET_ELAPSED_TIME_ON_NEW_FILE.property());
 
+			preferences.put(PROJECT_NAME.property(), projectName.getText());
 			preferences.putBoolean(USE_PROJECT_SETTINGS.property(), useProjectSettings.getSelection());
 			preferences.putBoolean(SHOW_PROJECT_NAME.property(), showProjectName.getSelection());
 			preferences.putBoolean(SHOW_FILE_NAME.property(), showFileName.getSelection());
@@ -223,12 +233,31 @@ public class ProjectPropertiesPage extends PropertyPage implements IWorkbenchPro
 	}
 
 	private void addPrivacySection(Composite parent) throws CoreException {
+		
+		// PROJECT NAME
+		
+		Group projectNameGroup = new Group(parent, SWT.NULL);
+		projectNameGroup.setText("Display");
+		GridLayout gridLayout = new GridLayout(2, false);
+		projectNameGroup.setLayout(gridLayout);
+		projectNameGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		
+		projectNameLabel = new Label(projectNameGroup, SWT.NULL);
+		projectNameLabel.setText("Name displayed for project: ");
+		
+		projectName = new Text(projectNameGroup, SWT.SINGLE | SWT.BORDER);
+		projectName.setText(project.getPersistentProperty(PROJECT_NAME.qualifiedName()));
+		GridData projectNameData = new GridData();
+		projectNameData.grabExcessHorizontalSpace = true;
+		projectNameData.horizontalAlignment = SWT.FILL;
+		projectName.setLayoutData(projectNameData);
+		
+		// PRIVACY GROUP
+		
 		Group privacy = new Group(parent, SWT.NONE);
 		privacy.setText("Privacy");
-		GridLayout gridLayout = new GridLayout();
-		gridLayout.numColumns = 1;
-		privacy.setLayout(gridLayout);
-		privacy.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		privacy.setLayout(new GridLayout());
+		privacy.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));	
 
 		showProjectName = new Button(privacy, SWT.CHECK);
 		showProjectName.setText("Show project name");

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/RunOnSettingChange.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/RunOnSettingChange.java
@@ -54,5 +54,10 @@ class RunOnSettingChange implements SettingChangeListener {
 	public void elapsedTimeResetMomentChanged(Moment oldMoment, Moment newMoment) {
 		updateDiscord.run();
 	}
+	
+	@Override
+	public void projectNameChanged(String oldName, String newName) {
+		updateDiscord.run();
+	}
 
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferences.java
@@ -15,12 +15,13 @@ import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSE
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_STARTUP;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_FILE_NAME;
-import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_LANGUAGE_ICON;
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.SHOW_PROJECT_NAME;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -91,6 +92,11 @@ public class GlobalPreferences implements UserPreferences {
 		return store.getString(RESET_ELAPSED_TIME.property()).equals(RESET_ELAPSED_TIME_ON_NEW_FILE.property());
 	}
 	
+	@Override
+	public Optional<String> getProjectName() {
+		return Optional.empty();
+	}
+	
 	/**
 	 * Returns the user preferences that should be applied for {@code project}.<br>
 	 * <br>
@@ -106,10 +112,19 @@ public class GlobalPreferences implements UserPreferences {
 	 */
 	public UserPreferences getApplicablePreferencesFor(IProject project) {
 		try {
-			ProjectPreferences projectPreferences = new ProjectPreferences(project);
+			final ProjectPreferences projectPreferences = new ProjectPreferences(project);
 			
 			if (projectPreferences.useProjectSettings())
 				return projectPreferences;
+			
+			// TODO [Refactor] Create a dedicated class ?
+			return new GlobalPreferences() {
+				
+				@Override
+				public Optional<String> getProjectName() {
+					return projectPreferences.getProjectName();
+				}
+			};
 		
 		} catch (IllegalArgumentException e) {
 			// The project is not valid, return default preferences

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferencesListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/GlobalPreferencesListener.java
@@ -9,6 +9,7 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.settings;
 
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_FILE;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_PROJECT;
@@ -54,6 +55,7 @@ public class GlobalPreferencesListener implements IPropertyChangeListener {
 	public GlobalPreferencesListener(Collection<SettingChangeListener> listeners) {
 		this.listeners = requireNonNull(listeners, "The collection of listeners must not be null");
 		
+		events.put(PROJECT_NAME.property(), (event, listener) -> {}); // Should never be called
 		events.put(SHOW_FILE_NAME.property(), (event, listener) -> listener.fileNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_PROJECT_NAME.property(), (event, listener) -> listener.projectNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferences.java
@@ -9,6 +9,7 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.settings;
 
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_FILE;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_PROJECT;
@@ -22,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
@@ -101,6 +103,16 @@ public class ProjectPreferences implements UserPreferences {
 	@Override
 	public boolean resetsElapsedTimeOnNewFile() {
 		return preferences.get(RESET_ELAPSED_TIME.property(), RESET_ELAPSED_TIME_ON_NEW_PROJECT.property()).equals(RESET_ELAPSED_TIME_ON_NEW_FILE.property());
+	}
+	
+	@Override
+	public Optional<String> getProjectName() {
+		String name = preferences.get(PROJECT_NAME.property(), "");
+		
+		if (name == null || name.trim().isEmpty())
+			return Optional.empty();
+		
+		return Optional.of(name);
 	}
 
 	/**

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferencesListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/ProjectPreferencesListener.java
@@ -9,6 +9,7 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.settings;
 
+import static fr.kazejiyu.discord.rpc.integration.settings.Settings.PROJECT_NAME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.USE_PROJECT_SETTINGS;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME;
 import static fr.kazejiyu.discord.rpc.integration.settings.Settings.RESET_ELAPSED_TIME_ON_NEW_FILE;
@@ -53,6 +54,7 @@ public class ProjectPreferencesListener implements IPreferenceChangeListener {
 	public ProjectPreferencesListener(Collection<SettingChangeListener> listeners) {
 		this.listeners = requireNonNull(listeners, "The collection of listeners must not be null");
 		
+		events.put(PROJECT_NAME.property(), (event, listener) -> listener.projectNameChanged(String.valueOf(event.getOldValue()), String.valueOf(event.getNewValue())));
 		events.put(SHOW_FILE_NAME.property(), (event, listener) -> listener.fileNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_PROJECT_NAME.property(), (event, listener) -> listener.projectNameVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));
 		events.put(SHOW_ELAPSED_TIME.property(), (event, listener) -> listener.elapsedTimeVisibilityChanged(Boolean.parseBoolean((String) event.getNewValue())));

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/SettingChangeListener.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/SettingChangeListener.java
@@ -71,4 +71,14 @@ public interface SettingChangeListener {
 	 */
 	void elapsedTimeResetMomentChanged(Moment oldMoment, Moment newMoment);
 	
+	/**
+	 * Called when the user choose to display a new name for a given project.
+	 * 
+	 * @param oldName
+	 * 			The previous name. May be {@code null} or empty.
+	 * @param newName
+	 * 			The new name to display
+	 */
+	void projectNameChanged(String oldName, String newName);
+	
 }

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/Settings.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/Settings.java
@@ -41,7 +41,9 @@ public enum Settings {
 	
 	SHOW_LANGUAGE_ICON("SHOW_LANGUAGE_ICON"),
 	
-	USE_PROJECT_SETTINGS("USE_PROJECT_SETTINGS");
+	USE_PROJECT_SETTINGS("USE_PROJECT_SETTINGS"),
+	
+	PROJECT_NAME("PROJECT_NAME");
 	
 	/** A key identifying the setting */
 	private final String property;

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/UserPreferences.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/settings/UserPreferences.java
@@ -9,6 +9,8 @@
 **********************************************************************/
 package fr.kazejiyu.discord.rpc.integration.settings;
 
+import java.util.Optional;
+
 /**
  * User preferences regarding the way information are shown in Discord.
  * 
@@ -36,5 +38,8 @@ public interface UserPreferences {
 	
 	/** @return whether the name of the current project should be shown in Discord */
 	boolean resetsElapsedTimeOnNewFile();
+	
+	/** @return the name of a given project, if the user specified one */
+	Optional<String> getProjectName();
 
 }


### PR DESCRIPTION
See [related US](https://tree.taiga.io/project/kazejiyu-eclipse-discord-integration/us/79).

Allows a user to set a custom name for its Eclipse Project that is shown in Discord.