### PR TITLE
Handle C language (fix #48)

### DIFF
--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/languages/Language.java
@@ -33,6 +33,7 @@ public enum Language {
 	BOO("boo", "Boo", "boo"),
 	CLOJURE("clojure", "Clojure", "clj"),
 	COBOL("cobol", "Cobol", "cob", "cbl", "cpy"),
+	C("c", "C", "c", "h"),
 	CPP("cpp", "C++", "cpp", "hpp"),
 	CRYSTAL("crystal", "Crystal", "cr"),
 	CSS("css3", "CSS", "css"),


### PR DESCRIPTION
Shows a dedicated icon in Discord when the file ends with either ".c" or ".h"