### PR TITLE
[fix #55] Properly close connection with Discord on workbench shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.1] - 2018-11-24
+### Fixed
+- Properly close connection with Discord on workbench shutdown
+
 ## [1.0.0] - 2018-08-23
 ### Added
 - Allow to deactivate the Rich Presence integration

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/Activator.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/Activator.java
@@ -30,6 +30,7 @@ import org.osgi.framework.BundleContext;
 import fr.kazejiyu.discord.rpc.integration.core.DiscordRpcProxy;
 import fr.kazejiyu.discord.rpc.integration.listener.AddListenerOnWindowOpened;
 import fr.kazejiyu.discord.rpc.integration.listener.FileChangeListener;
+import fr.kazejiyu.discord.rpc.integration.listener.OnPostShutdown;
 import fr.kazejiyu.discord.rpc.integration.settings.GlobalPreferences;
 
 /**
@@ -57,7 +58,7 @@ public class Activator extends AbstractUIPlugin implements IStartup {
 			listenForSelectionChangesWith(fileChange);
 			
 		} catch (Exception e) {
-			Plugin.logException("An error occurred while starting the Discord Rich Presence for Eclipse IDE plug-in", e);
+			Plugin.logException("An error occurred while starting the 'Discord Rich Presence for Eclipse IDE' plug-in", e);
 		}
 	}
 
@@ -80,7 +81,7 @@ public class Activator extends AbstractUIPlugin implements IStartup {
 		final IWorkbench workbench = PlatformUI.getWorkbench();
 		
 		workbench.addWindowListener(new AddListenerOnWindowOpened<>(listener));
-
+		workbench.addWorkbenchListener(new OnPostShutdown(iworkbench -> discord.close()));
 		workbench.getDisplay()
 				 .asyncExec(listenForSelectionInOpenedWindows(workbench));
 	}
@@ -89,6 +90,9 @@ public class Activator extends AbstractUIPlugin implements IStartup {
 	public void stop(BundleContext context) throws Exception {
 		try {
 			discord.shutdown();
+		}
+		catch (Exception e) {
+			Plugin.logException("An error occurred while shutting Discord Rich Presence down", e);
 		}
 		finally {
 			super.stop(context);

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/OnPostShutdown.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/listener/OnPostShutdown.java
@@ -1,0 +1,39 @@
+package fr.kazejiyu.discord.rpc.integration.listener;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Consumer;
+
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchListener;
+
+/**
+ * An {@link IWorkbenchListener} which behavior on {@link #postShutdown(IWorkbench) postShutdown}
+ * event can be parameterized. 
+ */
+public class OnPostShutdown implements IWorkbenchListener {
+	
+	/** Called on {@link #postShutdown(IWorkbench)} */
+	private final Consumer<IWorkbench> postShutdownCallback;
+	
+	/**
+	 * Creates a new listener.
+	 * 
+	 * @param postShutdownCallback
+	 * 			The callback to execute when the workbench is closed.
+	 */
+	public OnPostShutdown(Consumer<IWorkbench> postShutdownCallback) {
+		this.postShutdownCallback = requireNonNull(postShutdownCallback, "The callback must not be null");
+	}
+
+	@Override
+	public boolean preShutdown(IWorkbench workbench, boolean forced) {
+		return true;
+	}
+
+	@Override
+	public void postShutdown(IWorkbench workbench) {
+		postShutdownCallback.accept(workbench);
+	}
+	
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     
 	<modules>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.feature"
       label="Discord Rich Presence"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -354,14 +354,14 @@ You may add additional accurate notices of copyright ownership.
          id="fr.kazejiyu.discord.rpc.integration.adapters"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.ui.feature"
       label="Discord Rich Presence UI"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -345,7 +345,7 @@ You may add additional accurate notices of copyright ownership.
          id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,14 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
+	<!-- COMMANDS:	
+		* Change project's version:
+			mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=major.minor.bug
+
+		* Deploy current version on Bintray:
+			mvn clean verify -P release-composite
+	-->
+
 	<build>
 		<plugins>
 			<!-- Activate Tycho -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
     <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 	<packaging>pom</packaging>
     
 	<modules>
@@ -53,7 +53,7 @@
                         <artifact>
                             <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
                             <artifactId>fr.kazejiyu.discord.rpc.integration.target</artifactId>
-                            <version>1.0.0</version>
+                            <version>1.0.1</version>
                         </artifact>
                     </target>
 					<environments>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.0.0.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.0.0">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.0.1.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.0.1">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.0.0.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.0.0">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.0.1.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.0.1">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
    <category-def name="fr.kazejiyu.discord.rpc.integration" label="Discord Rich Presence Integration">

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>

--- a/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     
 	<modules>

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters.tests
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration.adapters;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 </project>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<profiles>
@@ -41,25 +41,25 @@
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.tests</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters.tests</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.tests
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 </project>

--- a/tests/org.assertj/META-INF/MANIFEST.MF
+++ b/tests/org.assertj/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Assertj
 Bundle-SymbolicName: org.assertj
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-ClassPath: assertj-core-3.9.0.jar
 Export-Package: org.assertj.core.api,
  org.assertj.core.api.exception,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     
 	<modules>


### PR DESCRIPTION
Ensures that the connection with Discord is not left opened when closing Eclipse IDE, preventing the process from staying alive.

Set project's version to `1.0.1`.