### PR TITLE
Show "Viewing fileName" when the current editor displays a .class file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.1] - 2020-07-05
+### Fixed
+ - [#85](https://github.com/echebbi/eclipse-discord-integration/issues/85) The 'editor_input_adapter' extension point asks for an instance of EditorInputRichPresence instead of EditorInputToRichPresenceAdapter
+
 ## [1.2.0] - 2020-05-01
 ### Fixed
  - [#79](https://github.com/echebbi/eclipse-discord-integration/pull/79) Prevent [custom project names](https://discord-rich-presence-for-eclipse-ide.readthedocs.io/en/latest/customize/change-name-of-projects.html#) from being ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.2.1] - 2020-07-05
+## [1.2.2] - 2020-07-05
+### Added
+ - [#84](https://github.com/echebbi/eclipse-discord-integration/issues/84) Show "Viewing _fileName_" when the current editor displays a _.class_ file
+
 ### Fixed
  - [#85](https://github.com/echebbi/eclipse-discord-integration/issues/85) The 'editor_input_adapter' extension point asks for an instance of EditorInputRichPresence instead of EditorInputToRichPresenceAdapter
+
+## [1.2.1] - 2020-06-05
+### Changed
+ - [#86](https://github.com/echebbi/eclipse-discord-integration/issues/86) The UI feature includes the core feature so that installing the first one automatically installs the later
 
 ## [1.2.0] - 2020-05-01
 ### Fixed

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -8,5 +8,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",
  org.eclipse.ui.workbench;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.11.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)"
+ org.eclipse.core.resources;bundle-version="[3.10.0,4.0.0)",
+ org.eclipse.jdt.ui;bundle-version="[3.0.0,4.0.0)";resolution:=optional,
+ org.eclipse.jdt.core;bundle-version="[3.0.0,4.0.0)";resolution:=optional,
+ org.eclipse.core.runtime;bundle-version="[3.0.0,4.0.0)";resolution:=optional
 Bundle-Vendor: Emmanuel CHEBBI

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters;singleton:=true
-Bundle-Version: 1.2.1
+Bundle-Version: 1.2.2
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.2",

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/plugin.xml
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/plugin.xml
@@ -9,6 +9,9 @@
       <adapter
             class="fr.kazejiyu.discord.rpc.integration.adapters.DefaultFileEditorInputRichPresence">
       </adapter>
+      <adapter
+            class="fr.kazejiyu.discord.rpc.integration.adapters.DefaultClassFileEditorInputRichPresence">
+      </adapter>
    </extension> 
 
 </plugin>

--- a/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultClassFileEditorInputRichPresence.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.adapters/src/fr/kazejiyu/discord/rpc/integration/adapters/DefaultClassFileEditorInputRichPresence.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2020 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.discord.rpc.integration.adapters;
+
+import static fr.kazejiyu.discord.rpc.integration.adapters.LanguageLabel.labelOf;
+
+import java.util.Optional;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.internal.ui.javaeditor.IClassFileEditorInput;
+import org.eclipse.ui.IEditorInput;
+
+import fr.kazejiyu.discord.rpc.integration.core.ImmutableRichPresence;
+import fr.kazejiyu.discord.rpc.integration.core.RichPresence;
+import fr.kazejiyu.discord.rpc.integration.extensions.EditorInputToRichPresenceAdapter;
+import fr.kazejiyu.discord.rpc.integration.languages.Language;
+import fr.kazejiyu.discord.rpc.integration.settings.GlobalPreferences;
+import fr.kazejiyu.discord.rpc.integration.settings.UserPreferences;
+
+/**
+ * <p>Default implementation of {@link EditorInputToRichPresenceAdapter}.</p>
+ * <p>
+ * This implementation only operates on {@link IClassFileEditorInput} instances and sets Rich Presence as follows:
+ * 
+ * <table style="border: 1px solid black ; border-collapse: collapse">
+ *     <tr style="border: 1px solid black">
+ *         <th style="border: 1px solid black">Property</th>
+ *         <th style="border: 1px solid black">Shown in Discord</th>
+ *     </tr>
+ *     <tr>
+ *         <td style="border: 1px solid black"><b>Details</b></td>
+ *         <td style="border: 1px solid black">Viewing <i>&lt;file.name&gt;</i></td>
+ *     </tr>
+ *     <tr>
+ *         <td style="border: 1px solid black"><b>State</b></td>
+ *         <td style="border: 1px solid black">Working on <i>&lt;project.name&gt;</i></td>
+ *     </tr>
+ * </table>
+ * </p>
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class DefaultClassFileEditorInputRichPresence implements EditorInputToRichPresenceAdapter {
+
+	private static final String DEFAULT_DETAILS_TEMPLATE = "Viewing ${file}";
+    private static final String DEFAULT_STATE_TEMPLATE = "Working on ${project}";
+    
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+    
+    @Override
+    public Class<IClassFileEditorInput> getExpectedEditorInputClass() {
+    	try {
+    		return IClassFileEditorInput.class;
+    	}
+    	catch (NoClassDefFoundError e) {
+    		// may happen since JDT dependencies are optional
+    		return null;
+    	}
+    }
+    
+    @Override
+    public Optional<RichPresence> createRichPresence(GlobalPreferences preferences, IEditorInput input) {
+        try {
+	    	if (!(input instanceof IClassFileEditorInput)) {
+	            throw new IllegalArgumentException("input must be an instance of " + IClassFileEditorInput.class);
+	        }
+	        IClassFileEditorInput fileInput = (IClassFileEditorInput) input;
+	        String fileName = fileInput.getName();
+	        Optional<IProject> project = projectDependingOn(fileInput.getClassFile());
+	        
+	        UserPreferences applicablePreferences = project.map(preferences::getApplicablePreferencesFor)
+	        											   .orElse(preferences);
+	        
+	        RichPresence presence = new ImmutableRichPresence()
+	        		.withProject(project.orElse(null))
+	                .withLanguage(Language.JAVA)
+	                .withDetails(detailsOf(applicablePreferences, project, fileName))
+	                .withState(stateOf(applicablePreferences, project, fileName))
+	                .withLargeImageText(largeImageTextOf(applicablePreferences, fileName));
+	        
+	        return Optional.of(presence);
+        }
+        catch (NoClassDefFoundError e) {
+        	// may happen since JDT dependencies are optional
+        	return Optional.empty();
+        }
+    }
+
+    private static Optional<IProject> projectDependingOn(IClassFile classFile) {
+		if (classFile == null || classFile.getJavaProject() == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(classFile.getJavaProject().getProject());
+	}
+
+	private static String detailsOf(UserPreferences preferences, Optional<IProject> project, String fileName) {
+        String template = preferences.getCustomDetailsWording().orElse(DEFAULT_DETAILS_TEMPLATE);
+        
+        template = template.replace("${file}", preferences.showsFileName() ? fileName : "?");
+        template = template.replace("${file.baseName}", preferences.showsFileName() ? getBaseFileName(fileName) : "?");
+        template = template.replace("${file.extension}", preferences.showsFileName() ? getFileExtension(fileName) : "?");
+        template = template.replace("${language}", Language.JAVA.getName());
+        template = template.replace("${project}", preferences.showsProjectName() ? project.map(IProject::getName).orElse("undetermined") : "?");
+        
+        return template;
+    }
+
+    private static String stateOf(UserPreferences preferences, Optional<IProject> project, String fileName) {
+        String template = preferences.getCustomStateWording().orElse(DEFAULT_STATE_TEMPLATE);
+        
+        template = template.replace("${file}", preferences.showsFileName() ? fileName : "?");
+        template = template.replace("${file.baseName}", preferences.showsFileName() ? getBaseFileName(fileName) : "?");
+        template = template.replace("${file.extension}", preferences.showsFileName() ? getFileExtension(fileName) : "?");
+        template = template.replace("${language}", Language.JAVA.getName());
+        template = template.replace("${project}", preferences.showsProjectName() ? project.map(IProject::getName).orElse("undetermined") : "?");
+        
+        return template;
+    }
+
+    private static String largeImageTextOf(UserPreferences preferences, String fileName) {
+        if (! preferences.showsLanguageIcon()) {
+            return "";
+        }
+        return labelOf(Language.JAVA, fileName);
+    }
+    
+    private static String getFileExtension(String fileName) {
+        if (!fileName.contains(".") || fileName.endsWith(".")) {
+            return "";
+        }
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
+    }
+    
+    private static String getBaseFileName(String fileName) {
+        if (!fileName.contains(".") || fileName.endsWith(".")) {
+            return fileName;
+        }
+        return fileName.substring(0, fileName.lastIndexOf('.'));
+    }
+
+}

--- a/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration.ui.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Preferences
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.ui.preferences;singleton:=true
-Bundle-Version: 1.2.1
+Bundle-Version: 1.2.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.ui.preferences.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration;singleton:=true
-Bundle-Version: 1.2.1
+Bundle-Version: 1.2.2
 Bundle-Activator: fr.kazejiyu.discord.rpc.integration.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_adapter.exsd
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/schema/editor_input_adapter.exsd
@@ -55,7 +55,7 @@
                   The adapter that extracts Rich Presence from a specific IEditorInput.
                </documentation>
                <appInfo>
-                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.discord.rpc.integration.extensions.EditorInputRichPresence"/>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.discord.rpc.integration.extensions.EditorInputToRichPresenceAdapter"/>
                </appInfo>
             </annotation>
          </attribute>

--- a/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/internal/EditorRichPresenceFromExtensions.java
+++ b/bundles/fr.kazejiyu.discord.rpc.integration/src/fr/kazejiyu/discord/rpc/integration/extensions/internal/EditorRichPresenceFromExtensions.java
@@ -94,7 +94,8 @@ public class EditorRichPresenceFromExtensions implements EditorRichPresenceFromI
 
     /** Returns whether {@code adapter} can handle {@code input}. */
     private static Predicate<EditorInputToRichPresenceAdapter> canHandle(IEditorInput input) {
-        return adapter -> adapter.getExpectedEditorInputClass().isInstance(input);
+        return adapter -> adapter.getExpectedEditorInputClass() != null
+        			   && adapter.getExpectedEditorInputClass().isInstance(input);
     }
     
     /**

--- a/bundles/java-discord-rpc/pom.xml
+++ b/bundles/java-discord-rpc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.bundles</artifactId>
-		<version>1.2.1</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>java-discord-rpc</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
     </parent>
 
 	<modules>

--- a/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.feature"
       label="Discord Rich Presence"
-      version="1.2.1"
+      version="1.2.2"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -312,14 +312,14 @@ version(s), and exceptions or additional permissions here}.&quot;
          id="fr.kazejiyu.discord.rpc.integration.adapters"
          download-size="0"
          install-size="0"
-         version="1.2.1"
+         version="1.2.2"
          unpack="false"/>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration"
          download-size="0"
          install-size="0"
-         version="1.2.1"
+         version="1.2.2"
          unpack="false"/>
 
 </feature>

--- a/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
+++ b/features/fr.kazejiyu.discord.rpc.integration.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="fr.kazejiyu.discord.rpc.integration.ui.feature"
       label="Discord Rich Presence UI (Preferences pages)"
-      version="1.2.1"
+      version="1.2.2"
       provider-name="Emmanuel CHEBBI">
 
    <description url="https://github.com/KazeJiyu/eclipse-discord-integration">
@@ -301,14 +301,14 @@ version(s), and exceptions or additional permissions here}.&quot;
       <import plugin="org.eclipse.ui" version="3.107.0" match="compatible"/>
       <import plugin="org.eclipse.core.runtime" version="3.11.0" match="compatible"/>
       <import plugin="org.eclipse.core.resources" version="3.10.0" match="compatible"/>
-      <import plugin="fr.kazejiyu.discord.rpc.integration" version="1.2.1" match="compatible"/>
+      <import plugin="fr.kazejiyu.discord.rpc.integration" version="1.2.2" match="compatible"/>
    </requires>
 
    <plugin
          id="fr.kazejiyu.discord.rpc.integration.ui.preferences"
          download-size="0"
          install-size="0"
-         version="1.2.1"
+         version="1.2.2"
          unpack="false"/>
 
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
     </parent>
     
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
     <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 	<packaging>pom</packaging>
 
 	<name>Discord Rich Presence for Eclipse IDE</name>
@@ -75,7 +75,7 @@
                         <artifact>
                             <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
                             <artifactId>fr.kazejiyu.discord.rpc.integration.target</artifactId>
-                            <version>1.2.1</version>
+                            <version>1.2.2</version>
                         </artifact>
                     </target>
 					<environments>

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.2.1.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.2.1">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.feature_1.2.2.jar" id="fr.kazejiyu.discord.rpc.integration.feature" version="1.2.2">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
-   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.2.1.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.2.1">
+   <feature url="features/fr.kazejiyu.discord.rpc.integration.ui.feature_1.2.2.jar" id="fr.kazejiyu.discord.rpc.integration.ui.feature" version="1.2.2">
       <category name="fr.kazejiyu.discord.rpc.integration"/>
    </feature>
    <category-def name="fr.kazejiyu.discord.rpc.integration" label="Discord Rich Presence Integration">

--- a/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.p2/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-		<version>1.2.1</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<artifactId>fr.kazejiyu.discord.rpc.integration.p2</artifactId>

--- a/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
+++ b/releng/fr.kazejiyu.discord.rpc.integration.target/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.releng</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
     </parent>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
     </parent>
     
 	<modules>

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE — Default Adapters (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.adapters.tests
-Bundle-Version: 1.2.1
+Bundle-Version: 1.2.2
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration.adapters;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.adapters.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.adapters.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.2.1</version>
+		<version>1.2.2</version>
 	</parent>
 </project>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests.report/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.2.1</version>
+		<version>1.2.2</version>
 	</parent>
 
 	<profiles>
@@ -41,25 +41,25 @@
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.tests</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 			<artifactId>fr.kazejiyu.discord.rpc.integration.adapters.tests</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Discord Rich Presence for Eclipse IDE (Tests)
 Bundle-SymbolicName: fr.kazejiyu.discord.rpc.integration.tests
-Bundle-Version: 1.2.1
+Bundle-Version: 1.2.2
 Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.discord.rpc.integration;bundle-version="0.8.4"
 Automatic-Module-Name: fr.kazejiyu.discord.rpc.integration.tests

--- a/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
+++ b/tests/fr.kazejiyu.discord.rpc.integration.tests/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>fr.kazejiyu.discord.rpc.integration</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.2.1</version>
+		<version>1.2.2</version>
 	</parent>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.kazejiyu.discord.rpc.integration</groupId>
         <artifactId>fr.kazejiyu.discord.rpc.integration.root</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
     </parent>
 
 	<modules>


### PR DESCRIPTION
Closes #84.

Manually tested on Eclipse 2020-06 (Java & CPP packages).

## Changes

 - a new IEditorInput adapter handles JDT's `IClassFileEditorInput`
 - adds dependencies on JDT; those are optional to make sure the plug-in can still be used when JDT is not installed